### PR TITLE
Add responsive secondary navigation bar

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -37,6 +37,125 @@
       </div>
     </div>
 
+    <nav class="secondary-nav" aria-label="Navegación secundaria">
+      <div class="secondary-nav__inner">
+        <button class="secondary-nav__toggle" type="button" aria-expanded="false" aria-controls="secondary-nav-menu">
+          <span class="secondary-nav__toggle-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect y="4" width="24" height="2.5" rx="1" fill="currentColor" />
+              <rect y="11" width="24" height="2.5" rx="1" fill="currentColor" />
+              <rect y="18" width="24" height="2.5" rx="1" fill="currentColor" />
+            </svg>
+          </span>
+          <span class="secondary-nav__toggle-label">Categorías</span>
+        </button>
+
+        <ul class="secondary-nav__menu" id="secondary-nav-menu">
+          <li class="nav-item nav-item--has-dropdown" data-menu="perfumes">
+            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
+              Perfumes
+              <span class="nav-link__icon" aria-hidden="true">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            </button>
+            <div class="dropdown-menu" role="menu">
+              <ul class="dropdown-list">
+                <li><a href="/productos?categoria=perfumes-masculinos" class="dropdown-link">Masculinas</a></li>
+                <li><a href="/productos?categoria=perfumes-femeninos" class="dropdown-link">Femeninas</a></li>
+              </ul>
+            </div>
+          </li>
+
+          <li class="nav-item">
+            <a href="#" class="nav-link nav-link--direct" data-href="/productos?categoria=vapes">
+              Vapes
+            </a>
+          </li>
+
+          <li class="nav-item nav-item--has-dropdown" data-menu="decants">
+            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
+              Decants
+              <span class="nav-link__icon" aria-hidden="true">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            </button>
+            <div class="dropdown-menu" role="menu">
+              <ul class="dropdown-list">
+                <li><a href="/productos?categoria=decants-masculinos" class="dropdown-link">Masculinas</a></li>
+                <li><a href="/productos?categoria=decants-femeninos" class="dropdown-link">Femeninas</a></li>
+                <li><a href="/productos?categoria=decants-combos" class="dropdown-link">Combos</a></li>
+              </ul>
+            </div>
+          </li>
+
+          <li class="nav-item nav-item--has-dropdown" data-menu="marcas">
+            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
+              Marcas
+              <span class="nav-link__icon" aria-hidden="true">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            </button>
+            <div class="dropdown-menu dropdown-menu--grid" role="menu">
+              <div class="dropdown-section">
+                <h4 class="dropdown-section__title">Perfumes</h4>
+                <ul class="dropdown-list" data-brand-list="perfumes" aria-label="Marcas de perfumes">
+                  <!-- JS insertará marcas -->
+                </ul>
+              </div>
+              <div class="dropdown-section">
+                <h4 class="dropdown-section__title">Vapes</h4>
+                <ul class="dropdown-list" data-brand-list="vapes" aria-label="Marcas de vapes">
+                  <!-- JS insertará marcas -->
+                </ul>
+              </div>
+            </div>
+          </li>
+
+          <li class="nav-item">
+            <a href="#" class="nav-link nav-link--direct" data-href="/productos?categoria=sale">
+              SALE
+            </a>
+          </li>
+
+          <li class="nav-item nav-item--has-dropdown" data-menu="faq">
+            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
+              Preguntas Frecuentes
+              <span class="nav-link__icon" aria-hidden="true">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            </button>
+            <div class="dropdown-menu" role="menu">
+              <ul class="dropdown-list">
+                <li>
+                  <button class="dropdown-link dropdown-link--faq" type="button">
+                    ¿Cuánto tarda el envío?
+                  </button>
+                </li>
+                <li>
+                  <button class="dropdown-link dropdown-link--faq" type="button">
+                    ¿Qué es un decant?
+                  </button>
+                </li>
+                <li>
+                  <button class="dropdown-link dropdown-link--faq" type="button">
+                    ¿Puedo pagar contra entrega?
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </nav>
+
     <nav class="header-categories">
       <ul id="menu-categorias">
         <!-- JS insertará categorías desde la API -->
@@ -194,3 +313,183 @@
     
 
 
+    const marcasPlaceholder = {
+      perfumes: ["Dior", "Chanel", "Yves Saint Laurent", "Tom Ford", "Carolina Herrera"],
+      vapes: ["Smok", "Vaporesso", "GeekVape", "Voopoo", "UWELL"]
+    };
+
+    const populateBrandDropdown = (brands = {}) => {
+      const perfumeList = document.querySelector('[data-brand-list="perfumes"]');
+      const vapeList = document.querySelector('[data-brand-list="vapes"]');
+
+      if (!perfumeList || !vapeList) {
+        return;
+      }
+
+      const createBrandItem = (brand, type) => {
+        const li = document.createElement('li');
+        li.innerHTML = `<a class="dropdown-link" href="/productos?marca=${brand.toLowerCase().replace(/\s+/g, '-')}&segmento=${type}">${brand}</a>`;
+        return li;
+      };
+
+      perfumeList.innerHTML = "";
+      vapeList.innerHTML = "";
+
+      (brands.perfumes || []).forEach(brand => {
+        perfumeList.appendChild(createBrandItem(brand, 'perfumes'));
+      });
+
+      (brands.vapes || []).forEach(brand => {
+        vapeList.appendChild(createBrandItem(brand, 'vapes'));
+      });
+    };
+
+    const initSecondaryNavigation = () => {
+      const secondaryNav = document.querySelector('.secondary-nav');
+      if (!secondaryNav) {
+        return;
+      }
+
+      const toggleButton = secondaryNav.querySelector('.secondary-nav__toggle');
+      const menu = secondaryNav.querySelector('.secondary-nav__menu');
+      const navItems = secondaryNav.querySelectorAll('.nav-item--has-dropdown');
+      const directLinks = secondaryNav.querySelectorAll('.nav-link--direct');
+
+      const toggleMenuVisibility = () => {
+        if (!toggleButton || !menu) {
+          return;
+        }
+
+        const isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
+        toggleButton.setAttribute('aria-expanded', String(!isExpanded));
+        menu.classList.toggle('secondary-nav__menu--open', !isExpanded);
+      };
+
+      if (toggleButton) {
+        toggleButton.addEventListener('click', toggleMenuVisibility);
+      }
+
+      navItems.forEach(item => {
+        const trigger = item.querySelector('.nav-link');
+        if (!trigger) {
+          return;
+        }
+
+        const openDropdown = () => {
+          item.classList.add('is-open');
+          trigger.setAttribute('aria-expanded', 'true');
+        };
+
+        const closeDropdown = () => {
+          item.classList.remove('is-open');
+          trigger.setAttribute('aria-expanded', 'false');
+        };
+
+        item.addEventListener('mouseenter', () => {
+          if (window.innerWidth > 900) {
+            openDropdown();
+          }
+        });
+
+        item.addEventListener('mouseleave', () => {
+          if (window.innerWidth > 900) {
+            closeDropdown();
+          }
+        });
+
+        trigger.addEventListener('focus', openDropdown);
+
+        item.addEventListener('focusout', event => {
+          if (!item.contains(event.relatedTarget)) {
+            closeDropdown();
+          }
+        });
+
+        trigger.addEventListener('click', event => {
+          if (window.innerWidth <= 900) {
+            event.preventDefault();
+            const willOpen = !item.classList.contains('is-open');
+            navItems.forEach(navItem => {
+              if (navItem !== item) {
+                navItem.classList.remove('is-open');
+                const navTrigger = navItem.querySelector('.nav-link');
+                if (navTrigger) {
+                  navTrigger.setAttribute('aria-expanded', 'false');
+                }
+              }
+            });
+            item.classList.toggle('is-open', willOpen);
+            trigger.setAttribute('aria-expanded', String(willOpen));
+          }
+        });
+      });
+
+      directLinks.forEach(link => {
+        link.addEventListener('click', event => {
+          event.preventDefault();
+          const target = link.getAttribute('data-href');
+          if (target) {
+            window.location.href = target;
+          }
+        });
+      });
+
+      let lastScrollY = window.scrollY;
+
+      const handleScroll = () => {
+        const currentScroll = window.scrollY;
+
+        if (currentScroll > lastScrollY && currentScroll > 120) {
+          secondaryNav.classList.add('secondary-nav--hidden');
+        } else {
+          secondaryNav.classList.remove('secondary-nav--hidden');
+        }
+
+        if (header) {
+          header.classList.toggle('header--scrolled', currentScroll > 40);
+        }
+
+        lastScrollY = currentScroll;
+      };
+
+      window.addEventListener('scroll', handleScroll, { passive: true });
+
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 900 && menu) {
+          menu.classList.remove('secondary-nav__menu--open');
+          if (toggleButton) {
+            toggleButton.setAttribute('aria-expanded', 'false');
+          }
+        }
+
+        navItems.forEach(item => {
+          const trigger = item.querySelector('.nav-link');
+          if (window.innerWidth > 900) {
+            item.classList.remove('is-open');
+            if (trigger) {
+              trigger.setAttribute('aria-expanded', 'false');
+            }
+          }
+        });
+      });
+
+      window.dispatchEvent(new Event('scroll'));
+      updateCategoriesHeight();
+    };
+
+    const simulateBrandsFetch = () => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve(marcasPlaceholder);
+        }, 350);
+      });
+    };
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      renderCategorias(categoriasFallback);
+      initSecondaryNavigation();
+      populateBrandDropdown(await simulateBrandsFetch());
+    });
+  </script>
+</body>
+</html>

--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -129,6 +129,215 @@ body {
   font-size: 0.9rem;
 }
 
+.secondary-nav {
+  margin: 0 auto 12px;
+  background: #f8f9fb;
+  border: 1px solid rgba(0, 74, 173, 0.08);
+  border-radius: 16px;
+  padding: 6px 14px;
+  position: relative;
+  transition: transform 0.35s ease, opacity 0.35s ease;
+}
+
+.secondary-nav--hidden {
+  transform: translateY(-120%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.secondary-nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.secondary-nav__toggle {
+  background: #004aad;
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  gap: 10px;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.secondary-nav__toggle:focus-visible {
+  outline: 2px solid rgba(0, 74, 173, 0.45);
+  outline-offset: 2px;
+}
+
+.secondary-nav__toggle:hover {
+  background: #003b89;
+  transform: translateY(-1px);
+}
+
+.secondary-nav__menu {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.nav-item {
+  position: relative;
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: center;
+}
+
+.nav-link {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: #1b1b1b;
+  font-size: 0.95rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.nav-link:focus-visible,
+.nav-link:hover,
+.nav-link.nav-link--direct:focus-visible,
+.nav-link.nav-link--direct:hover {
+  background: rgba(0, 74, 173, 0.1);
+  color: #004aad;
+  box-shadow: 0 8px 20px rgba(0, 74, 173, 0.12);
+}
+
+.nav-link__icon {
+  display: inline-flex;
+  transform: rotate(0deg);
+  transition: transform 0.3s ease;
+}
+
+.nav-item.is-open .nav-link__icon {
+  transform: rotate(180deg);
+}
+
+.nav-link.nav-link--direct {
+  text-decoration: none;
+}
+
+.dropdown-menu {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 12px);
+  transform: translate(-50%, 10px);
+  background: #fff;
+  border-radius: 16px;
+  padding: 18px 22px;
+  box-shadow: 0 15px 35px rgba(15, 35, 95, 0.12);
+  opacity: 0;
+  pointer-events: none;
+  min-width: 200px;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 20;
+}
+
+.nav-item.is-open .dropdown-menu {
+  opacity: 1;
+  transform: translate(-50%, 0px);
+  pointer-events: auto;
+}
+
+.dropdown-menu--grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  gap: 24px;
+  min-width: 360px;
+}
+
+.dropdown-section__title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: #6b7a99;
+  margin-bottom: 10px;
+  letter-spacing: 0.08em;
+}
+
+.dropdown-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dropdown-link {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  color: #1b1b1b;
+  text-decoration: none;
+  font-size: 0.9rem;
+  background: transparent;
+  border: none;
+  padding: 6px 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+
+.dropdown-link:hover,
+.dropdown-link:focus-visible {
+  color: #004aad;
+}
+
+.dropdown-link::before {
+  content: '•';
+  color: rgba(0, 74, 173, 0.4);
+  font-size: 0.8rem;
+  display: inline-flex;
+}
+
+.dropdown-link--faq::before {
+  content: '❓';
+  font-size: 0.9rem;
+  color: rgba(0, 74, 173, 0.6);
+}
+
+.secondary-nav__menu--open {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+}
+
+.nav-item--has-dropdown .dropdown-menu {
+  text-align: left;
+}
+
+.nav-item--has-dropdown .dropdown-menu::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: -4px -4px 12px rgba(15, 35, 95, 0.04);
+  clip-path: polygon(50% 0, 0 100%, 100% 100%);
+}
+
 .header-categories {
   border-top: 1px solid #e6e6e6;
   overflow: hidden;
@@ -170,6 +379,88 @@ body {
 .main-header.header--scrolled .header-categories ul {
   padding-top: 0;
   padding-bottom: 0;
+}
+
+@media (max-width: 1024px) {
+  .nav-link {
+    font-size: 0.9rem;
+    padding: 10px 12px;
+  }
+
+  .dropdown-menu {
+    min-width: 180px;
+  }
+
+  .dropdown-menu--grid {
+    grid-template-columns: 1fr;
+    min-width: 260px;
+  }
+}
+
+@media (max-width: 900px) {
+  .secondary-nav {
+    padding: 10px;
+  }
+
+  .secondary-nav__inner {
+    align-items: stretch;
+  }
+
+  .secondary-nav__toggle {
+    display: inline-flex;
+  }
+
+  .secondary-nav__menu {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .secondary-nav__menu--open {
+    display: flex;
+  }
+
+  .nav-item {
+    justify-content: flex-start;
+  }
+
+  .nav-link {
+    justify-content: space-between;
+  }
+
+  .dropdown-menu {
+    position: static;
+    transform: translate(0, 0);
+    box-shadow: none;
+    border: 1px solid rgba(0, 74, 173, 0.08);
+    margin-top: 10px;
+    opacity: 1;
+    pointer-events: auto;
+    display: none;
+  }
+
+  .nav-item.is-open .dropdown-menu {
+    display: block;
+  }
+
+  .nav-item--has-dropdown .dropdown-menu::before {
+    display: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .secondary-nav {
+    border-radius: 14px;
+  }
+
+  .secondary-nav__toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .nav-link {
+    font-size: 0.95rem;
+  }
 }
 
 /* =======================


### PR DESCRIPTION
## Summary
- add a secondary navigation bar with dropdown categories, FAQ shortcuts, and responsive toggle controls
- style the new menu with modern rounded visuals, hover animations, and mobile-friendly layouts
- implement JavaScript to populate API placeholder brands, manage dropdowns, and hide the bar on scroll

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbeec5b550832ea3070d4399ea6a2b