### PR TITLE
Refactor header layout with dual-row navigation

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -16,149 +16,99 @@
   <div class="container">
 
   <!-- Header -->
-  <header class="main-header">
-    <div class="header-top">
-      <div class="logo">Vesper</div>
-      <div class="search-bar">
-        <input type="text" id="search-input" placeholder="Descubrí perfumes, marcas...">
-        <button id="search-btn" aria-label="Buscar">
-          <span class="icon">🔍</span>
+  <header class="site-header" role="banner">
+    <div class="site-header__top">
+      <a href="/" class="site-header__logo" aria-label="Vesper home">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='48' viewBox='0 0 160 48'%3E%3Crect width='160' height='48' fill='white'/%3E%3Ctext x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='Merriweather, serif' font-size='32' fill='%23004aad'%3EVesper%3C/text%3E%3C/svg%3E" alt="Vesper">
+      </a>
+      <form class="site-header__search" role="search">
+        <label class="visually-hidden" for="search-input">Buscar en Vesper</label>
+        <input type="search" id="search-input" name="search" placeholder="Buscar perfumes, marcas..." aria-label="Buscar perfumes y marcas">
+        <button type="submit" aria-label="Buscar">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="11" cy="11" r="6" stroke="currentColor" stroke-width="2"></circle>
+            <path d="M20 20l-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+          </svg>
         </button>
-      </div>
-      <div class="header-actions">
-        <a href="#" class="header-action" id="link-cuenta">
-          <span class="icon" aria-hidden="true">👤</span>
-          <span class="label">Mi cuenta</span>
+      </form>
+      <div class="site-header__actions">
+        <a href="#" class="site-header__action" id="link-cuenta">
+          <span class="site-header__action-icon" aria-hidden="true">👤</span>
+          <span class="site-header__action-label">Mi cuenta</span>
         </a>
-        <a href="#" class="header-action" id="link-carrito">
-          <span class="icon" aria-hidden="true">🛒</span>
-          <span class="label">Carrito (<span id="cart-count">0</span>)</span>
+        <a href="#" class="site-header__action" id="link-carrito">
+          <span class="site-header__action-icon" aria-hidden="true">🛒</span>
+          <span class="site-header__action-label">Carrito (<span id="cart-count">0</span>)</span>
         </a>
       </div>
     </div>
 
-    <nav class="secondary-nav" aria-label="Navegación secundaria">
-      <div class="secondary-nav__inner">
-        <button class="secondary-nav__toggle" type="button" aria-expanded="false" aria-controls="secondary-nav-menu">
-          <span class="secondary-nav__toggle-icon" aria-hidden="true">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect y="4" width="24" height="2.5" rx="1" fill="currentColor" />
-              <rect y="11" width="24" height="2.5" rx="1" fill="currentColor" />
-              <rect y="18" width="24" height="2.5" rx="1" fill="currentColor" />
-            </svg>
-          </span>
-          <span class="secondary-nav__toggle-label">Categorías</span>
-        </button>
-
-        <ul class="secondary-nav__menu" id="secondary-nav-menu">
-          <li class="nav-item nav-item--has-dropdown" data-menu="perfumes">
-            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
-              Perfumes
-              <span class="nav-link__icon" aria-hidden="true">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-            </button>
-            <div class="dropdown-menu" role="menu">
-              <ul class="dropdown-list">
-                <li><a href="/productos?categoria=perfumes-masculinos" class="dropdown-link">Masculinas</a></li>
-                <li><a href="/productos?categoria=perfumes-femeninos" class="dropdown-link">Femeninas</a></li>
+    <nav class="site-header__bottom" aria-label="Categorías principales">
+      <ul class="main-nav">
+        <li class="main-nav__item main-nav__item--has-dropdown" data-dropdown="perfumes">
+          <button class="main-nav__link" type="button" aria-haspopup="true" aria-expanded="false">
+            Perfumes
+            <span class="main-nav__icon" aria-hidden="true">▾</span>
+          </button>
+          <div class="main-nav__dropdown" role="menu">
+            <ul class="main-nav__list">
+              <li><a href="/productos?categoria=perfumes-masculinas" class="main-nav__dropdown-link" role="menuitem">Masculinas</a></li>
+              <li><a href="/productos?categoria=perfumes-femeninas" class="main-nav__dropdown-link" role="menuitem">Femeninas</a></li>
+            </ul>
+          </div>
+        </li>
+        <li class="main-nav__item">
+          <a href="/productos?categoria=vapes" class="main-nav__link main-nav__link--direct">Vapes</a>
+        </li>
+        <li class="main-nav__item main-nav__item--has-dropdown" data-dropdown="decants">
+          <button class="main-nav__link" type="button" aria-haspopup="true" aria-expanded="false">
+            Decants
+            <span class="main-nav__icon" aria-hidden="true">▾</span>
+          </button>
+          <div class="main-nav__dropdown" role="menu">
+            <ul class="main-nav__list">
+              <li><a href="/productos?categoria=decants-masculinas" class="main-nav__dropdown-link" role="menuitem">Masculinas</a></li>
+              <li><a href="/productos?categoria=decants-femeninas" class="main-nav__dropdown-link" role="menuitem">Femeninas</a></li>
+              <li><a href="/productos?categoria=decants-combos" class="main-nav__dropdown-link" role="menuitem">Combos</a></li>
+            </ul>
+          </div>
+        </li>
+        <li class="main-nav__item main-nav__item--has-dropdown" data-dropdown="marcas">
+          <button class="main-nav__link" type="button" aria-haspopup="true" aria-expanded="false">
+            Marcas
+            <span class="main-nav__icon" aria-hidden="true">▾</span>
+          </button>
+          <div class="main-nav__dropdown main-nav__dropdown--columns" role="menu">
+            <div class="main-nav__column">
+              <h4 class="main-nav__column-title">Perfumes</h4>
+              <ul class="main-nav__list" data-brand-list="perfumes" aria-label="Marcas de perfumes">
+                <!-- JS insertará marcas -->
               </ul>
             </div>
-          </li>
-
-          <li class="nav-item">
-            <a href="#" class="nav-link nav-link--direct" data-href="/productos?categoria=vapes">
-              Vapes
-            </a>
-          </li>
-
-          <li class="nav-item nav-item--has-dropdown" data-menu="decants">
-            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
-              Decants
-              <span class="nav-link__icon" aria-hidden="true">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-            </button>
-            <div class="dropdown-menu" role="menu">
-              <ul class="dropdown-list">
-                <li><a href="/productos?categoria=decants-masculinos" class="dropdown-link">Masculinas</a></li>
-                <li><a href="/productos?categoria=decants-femeninos" class="dropdown-link">Femeninas</a></li>
-                <li><a href="/productos?categoria=decants-combos" class="dropdown-link">Combos</a></li>
+            <div class="main-nav__column">
+              <h4 class="main-nav__column-title">Vapes</h4>
+              <ul class="main-nav__list" data-brand-list="vapes" aria-label="Marcas de vapes">
+                <!-- JS insertará marcas -->
               </ul>
             </div>
-          </li>
-
-          <li class="nav-item nav-item--has-dropdown" data-menu="marcas">
-            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
-              Marcas
-              <span class="nav-link__icon" aria-hidden="true">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-            </button>
-            <div class="dropdown-menu dropdown-menu--grid" role="menu">
-              <div class="dropdown-section">
-                <h4 class="dropdown-section__title">Perfumes</h4>
-                <ul class="dropdown-list" data-brand-list="perfumes" aria-label="Marcas de perfumes">
-                  <!-- JS insertará marcas -->
-                </ul>
-              </div>
-              <div class="dropdown-section">
-                <h4 class="dropdown-section__title">Vapes</h4>
-                <ul class="dropdown-list" data-brand-list="vapes" aria-label="Marcas de vapes">
-                  <!-- JS insertará marcas -->
-                </ul>
-              </div>
-            </div>
-          </li>
-
-          <li class="nav-item">
-            <a href="#" class="nav-link nav-link--direct" data-href="/productos?categoria=sale">
-              SALE
-            </a>
-          </li>
-
-          <li class="nav-item nav-item--has-dropdown" data-menu="faq">
-            <button class="nav-link" type="button" aria-haspopup="true" aria-expanded="false">
-              Preguntas Frecuentes
-              <span class="nav-link__icon" aria-hidden="true">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-            </button>
-            <div class="dropdown-menu" role="menu">
-              <ul class="dropdown-list">
-                <li>
-                  <button class="dropdown-link dropdown-link--faq" type="button">
-                    ¿Cuánto tarda el envío?
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-link dropdown-link--faq" type="button">
-                    ¿Qué es un decant?
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-link dropdown-link--faq" type="button">
-                    ¿Puedo pagar contra entrega?
-                  </button>
-                </li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </nav>
-
-    <nav class="header-categories">
-      <ul id="menu-categorias">
-        <!-- JS insertará categorías desde la API -->
+          </div>
+        </li>
+        <li class="main-nav__item">
+          <a href="/productos?categoria=sale" class="main-nav__link main-nav__link--direct">SALE</a>
+        </li>
+        <li class="main-nav__item main-nav__item--has-dropdown" data-dropdown="faq">
+          <button class="main-nav__link" type="button" aria-haspopup="true" aria-expanded="false">
+            Preguntas Frecuentes
+            <span class="main-nav__icon" aria-hidden="true">▾</span>
+          </button>
+          <div class="main-nav__dropdown" role="menu">
+            <ul class="main-nav__list">
+              <li><a href="#faq-envio" class="main-nav__dropdown-link" role="menuitem">¿Cuánto tarda el envío?</a></li>
+              <li><a href="#faq-decant" class="main-nav__dropdown-link" role="menuitem">¿Qué es un decant?</a></li>
+              <li><a href="#faq-pago" class="main-nav__dropdown-link" role="menuitem">¿Puedo pagar contra entrega?</a></li>
+            </ul>
+          </div>
+        </li>
       </ul>
     </nav>
   </header>
@@ -257,50 +207,6 @@
 
   <!-- Script para cargar dinámicamente datos desde API -->
   <script>
-    const header = document.querySelector('.main-header');
-    const headerCategories = document.querySelector('.header-categories');
-
-    const updateCategoriesHeight = () => {
-      if (headerCategories) {
-        headerCategories.style.setProperty('--categories-height', `${headerCategories.scrollHeight}px`);
-      }
-    };
-
-    const renderCategorias = (categorias = []) => {
-      const menu = document.getElementById("menu-categorias");
-      const footer = document.getElementById("footer-categorias");
-      const catList = document.getElementById("category-list");
-
-      if (!menu || !footer || !catList) {
-        updateCategoriesHeight();
-        return;
-      }
-
-      menu.innerHTML = "";
-      footer.innerHTML = "";
-      catList.innerHTML = "";
-
-      categorias.forEach(cat => {
-        const { id, nombre, descripcion } = cat;
-        const link = id ? `/categoria/${id}` : "#";
-
-        const li = document.createElement("li");
-        li.innerHTML = `<a href="${link}">${nombre}</a>`;
-        menu.appendChild(li);
-
-        const liFooter = document.createElement("li");
-        liFooter.innerHTML = `<a href="${link}">${nombre}</a>`;
-        footer.appendChild(liFooter);
-
-        const div = document.createElement("div");
-        div.classList.add("category");
-        div.innerHTML = `<h3>${nombre}</h3><p>${descripcion || ""}</p>`;
-        catList.appendChild(div);
-      });
-
-      updateCategoriesHeight();
-    };
-
     const categoriasFallback = [
       { id: "fragancias", nombre: "Fragancias", descripcion: "Aromas para cada estilo." },
       { id: "descuentos", nombre: "Descuentos", descripcion: "Promociones imperdibles de la semana." },
@@ -310,8 +216,36 @@
       { id: "faq", nombre: "Preguntas frecuentes", descripcion: "Resolvé tus dudas al instante." }
     ];
 
-    
+    const renderCategorias = (categorias = []) => {
+      const footer = document.getElementById('footer-categorias');
+      const catList = document.getElementById('category-list');
 
+      if (footer) {
+        footer.innerHTML = '';
+      }
+
+      if (catList) {
+        catList.innerHTML = '';
+      }
+
+      categorias.forEach(cat => {
+        const { id, nombre, descripcion } = cat;
+        const link = id ? `/categoria/${id}` : '#';
+
+        if (footer) {
+          const liFooter = document.createElement('li');
+          liFooter.innerHTML = `<a href="${link}">${nombre}</a>`;
+          footer.appendChild(liFooter);
+        }
+
+        if (catList) {
+          const div = document.createElement('div');
+          div.classList.add('category');
+          div.innerHTML = `<h3>${nombre}</h3><p>${descripcion || ''}</p>`;
+          catList.appendChild(div);
+        }
+      });
+    };
 
     const marcasPlaceholder = {
       perfumes: ["Dior", "Chanel", "Yves Saint Laurent", "Tom Ford", "Carolina Herrera"],
@@ -344,61 +278,58 @@
       });
     };
 
-    const initSecondaryNavigation = () => {
-      const secondaryNav = document.querySelector('.secondary-nav');
-      if (!secondaryNav) {
+    const initDropdownNavigation = () => {
+      const dropdownItems = document.querySelectorAll('.main-nav__item--has-dropdown');
+      if (!dropdownItems.length) {
         return;
       }
 
-      const toggleButton = secondaryNav.querySelector('.secondary-nav__toggle');
-      const menu = secondaryNav.querySelector('.secondary-nav__menu');
-      const navItems = secondaryNav.querySelectorAll('.nav-item--has-dropdown');
-      const directLinks = secondaryNav.querySelectorAll('.nav-link--direct');
-
-      const toggleMenuVisibility = () => {
-        if (!toggleButton || !menu) {
-          return;
+      const closeItem = item => {
+        const trigger = item.querySelector('.main-nav__link');
+        if (trigger) {
+          trigger.setAttribute('aria-expanded', 'false');
         }
-
-        const isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
-        toggleButton.setAttribute('aria-expanded', String(!isExpanded));
-        menu.classList.toggle('secondary-nav__menu--open', !isExpanded);
+        item.classList.remove('is-open');
       };
 
-      if (toggleButton) {
-        toggleButton.addEventListener('click', toggleMenuVisibility);
-      }
+      const openItem = item => {
+        const trigger = item.querySelector('.main-nav__link');
+        if (trigger) {
+          trigger.setAttribute('aria-expanded', 'true');
+        }
+        item.classList.add('is-open');
+      };
 
-      navItems.forEach(item => {
-        const trigger = item.querySelector('.nav-link');
-        if (!trigger) {
+      const closeAllExcept = current => {
+        dropdownItems.forEach(item => {
+          if (item !== current) {
+            closeItem(item);
+          }
+        });
+      };
+
+      dropdownItems.forEach(item => {
+        const trigger = item.querySelector('.main-nav__link');
+        const dropdown = item.querySelector('.main-nav__dropdown');
+        if (!trigger || !dropdown) {
           return;
         }
 
+        trigger.setAttribute('aria-expanded', 'false');
+
         const openDropdown = () => {
-          item.classList.add('is-open');
-          trigger.setAttribute('aria-expanded', 'true');
+          closeAllExcept(item);
+          openItem(item);
         };
 
         const closeDropdown = () => {
-          item.classList.remove('is-open');
-          trigger.setAttribute('aria-expanded', 'false');
+          closeItem(item);
         };
 
-        item.addEventListener('mouseenter', () => {
-          if (window.innerWidth > 900) {
-            openDropdown();
-          }
-        });
-
-        item.addEventListener('mouseleave', () => {
-          if (window.innerWidth > 900) {
-            closeDropdown();
-          }
-        });
+        item.addEventListener('mouseenter', openDropdown);
+        item.addEventListener('mouseleave', closeDropdown);
 
         trigger.addEventListener('focus', openDropdown);
-
         item.addEventListener('focusout', event => {
           if (!item.contains(event.relatedTarget)) {
             closeDropdown();
@@ -406,75 +337,45 @@
         });
 
         trigger.addEventListener('click', event => {
-          if (window.innerWidth <= 900) {
+          event.preventDefault();
+          const willOpen = !item.classList.contains('is-open');
+          if (willOpen) {
+            closeAllExcept(item);
+            openItem(item);
+          } else {
+            closeDropdown();
+          }
+        });
+
+        trigger.addEventListener('keydown', event => {
+          if (event.key === 'Escape') {
+            closeDropdown();
+            trigger.blur();
+          }
+
+          if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             const willOpen = !item.classList.contains('is-open');
-            navItems.forEach(navItem => {
-              if (navItem !== item) {
-                navItem.classList.remove('is-open');
-                const navTrigger = navItem.querySelector('.nav-link');
-                if (navTrigger) {
-                  navTrigger.setAttribute('aria-expanded', 'false');
-                }
-              }
-            });
-            item.classList.toggle('is-open', willOpen);
-            trigger.setAttribute('aria-expanded', String(willOpen));
-          }
-        });
-      });
-
-      directLinks.forEach(link => {
-        link.addEventListener('click', event => {
-          event.preventDefault();
-          const target = link.getAttribute('data-href');
-          if (target) {
-            window.location.href = target;
-          }
-        });
-      });
-
-      let lastScrollY = window.scrollY;
-
-      const handleScroll = () => {
-        const currentScroll = window.scrollY;
-
-        if (currentScroll > lastScrollY && currentScroll > 120) {
-          secondaryNav.classList.add('secondary-nav--hidden');
-        } else {
-          secondaryNav.classList.remove('secondary-nav--hidden');
-        }
-
-        if (header) {
-          header.classList.toggle('header--scrolled', currentScroll > 40);
-        }
-
-        lastScrollY = currentScroll;
-      };
-
-      window.addEventListener('scroll', handleScroll, { passive: true });
-
-      window.addEventListener('resize', () => {
-        if (window.innerWidth > 900 && menu) {
-          menu.classList.remove('secondary-nav__menu--open');
-          if (toggleButton) {
-            toggleButton.setAttribute('aria-expanded', 'false');
-          }
-        }
-
-        navItems.forEach(item => {
-          const trigger = item.querySelector('.nav-link');
-          if (window.innerWidth > 900) {
-            item.classList.remove('is-open');
-            if (trigger) {
-              trigger.setAttribute('aria-expanded', 'false');
+            if (willOpen) {
+              closeAllExcept(item);
+              openItem(item);
+            } else {
+              closeDropdown();
             }
           }
         });
+
+        dropdown.addEventListener('keydown', event => {
+          if (event.key === 'Escape') {
+            closeDropdown();
+            trigger.focus();
+          }
+        });
       });
 
-      window.dispatchEvent(new Event('scroll'));
-      updateCategoriesHeight();
+      window.addEventListener('resize', () => {
+        dropdownItems.forEach(closeItem);
+      });
     };
 
     const simulateBrandsFetch = () => {
@@ -485,9 +386,34 @@
       });
     };
 
+    const initHeaderScrollBehavior = () => {
+      const headerBottom = document.querySelector('.site-header__bottom');
+      if (!headerBottom) {
+        return;
+      }
+
+      let lastScrollY = window.scrollY;
+
+      const handleScroll = () => {
+        const currentScroll = window.scrollY;
+
+        if (currentScroll > lastScrollY && currentScroll > 120) {
+          headerBottom.classList.add('site-header__bottom--collapsed');
+        } else {
+          headerBottom.classList.remove('site-header__bottom--collapsed');
+        }
+
+        lastScrollY = currentScroll;
+      };
+
+      window.addEventListener('scroll', handleScroll, { passive: true });
+      handleScroll();
+    };
+
     document.addEventListener('DOMContentLoaded', async () => {
       renderCategorias(categoriasFallback);
-      initSecondaryNavigation();
+      initDropdownNavigation();
+      initHeaderScrollBehavior();
       populateBrandDropdown(await simulateBrandsFetch());
     });
   </script>

--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -37,429 +37,337 @@ body {
 /* =======================
    Header
 ======================= */
-.main-header {
+.site-header {
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: #fff;
-  border-top: 2px solid #004aad;
-  border-bottom: 1px solid #cdcdcd;
-  padding: 0 0 5px;
-  transition: box-shadow 0.3s ease;
+  background: #ffffff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
-.main-header.header--scrolled {
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-}
-
-.header-top {
+.site-header__top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 40px;
-  padding: 15px 0 10px;
+  gap: 32px;
+  padding: 18px 0;
 }
 
-.logo {
-  font-family: 'Merriweather', serif;
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: #004aad;
+.site-header__logo img {
+  display: block;
+  max-height: 48px;
 }
 
-.search-bar {
+.site-header__search {
   flex: 1;
-  margin: 0 40px;
   display: flex;
   align-items: center;
-}
-
-.search-bar input {
-  flex: 1;
-  padding: 10px 15px;
+  gap: 8px;
+  max-width: 520px;
+  background: #ffffff;
+  padding: 4px;
+  border-radius: 999px;
   border: 1px solid #cdcdcd;
-  border-radius: 5px 0 0 5px;
-  border-right: none;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
-.search-bar input:focus {
-  outline: none;
+.site-header__search:focus-within {
   border-color: #004aad;
-  box-shadow: 0 0 0 2px rgba(0, 74, 173, 0.15);
+  box-shadow: 0 0 0 4px rgba(0, 74, 173, 0.12);
 }
 
-.search-bar button {
-  background: #004aad;
-  color: #fff;
+.site-header__search input {
+  flex: 1;
   border: none;
-  padding: 10px 18px;
-  border-radius: 0 5px 5px 0;
-  cursor: pointer;
-  display: flex;
+  padding: 10px 16px;
+  font-size: 0.95rem;
+  border-radius: 999px;
+}
+
+.site-header__search input:focus {
+  outline: none;
+}
+
+.site-header__search button {
+  background: #004aad;
+  color: #ffffff;
+  border: none;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
 }
 
-.header-actions {
+.site-header__search button:hover,
+.site-header__search button:focus-visible {
+  background: #003b89;
+  transform: translateY(-1px);
+}
+
+.site-header__actions {
   display: flex;
   align-items: center;
   gap: 20px;
 }
 
-.header-action {
-  display: flex;
+.site-header__action {
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: #333;
+  gap: 8px;
+  color: #1b1b1b;
   text-decoration: none;
   font-weight: 500;
-  font-size: 0.95rem;
+  transition: color 0.3s ease;
 }
 
-.header-action:hover {
+.site-header__action:hover,
+.site-header__action:focus-visible {
   color: #004aad;
 }
 
-.header-action .icon {
-  font-size: 1.1rem;
+.site-header__action-icon {
+  font-size: 1.2rem;
 }
 
-.header-action .label {
-  white-space: nowrap;
-  font-size: 0.9rem;
+.site-header__bottom {
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  overflow: hidden;
 }
 
-.secondary-nav {
-  margin: 0 auto 12px;
-  background: #f8f9fb;
-  border: 1px solid rgba(0, 74, 173, 0.08);
-  border-radius: 16px;
-  padding: 6px 14px;
-  position: relative;
-  transition: transform 0.35s ease, opacity 0.35s ease;
-}
-
-.secondary-nav--hidden {
-  transform: translateY(-120%);
-  opacity: 0;
-  pointer-events: none;
-}
-
-.secondary-nav__inner {
+.site-header__bottom-inner,
+.main-nav {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  justify-content: center;
+  gap: 24px;
+  list-style: none;
+  padding: 12px 0;
+  margin: 0;
 }
 
-.secondary-nav__toggle {
-  background: #004aad;
-  color: #fff;
-  border: none;
-  padding: 10px 16px;
-  border-radius: 12px;
-  cursor: pointer;
-  display: none;
-  align-items: center;
-  gap: 10px;
-  font-family: inherit;
+.main-nav__item {
+  position: relative;
+}
+
+.main-nav__link {
+  font-family: 'Poppins', sans-serif;
   font-size: 0.95rem;
   font-weight: 500;
-  transition: background 0.3s ease, transform 0.3s ease;
-}
-
-.secondary-nav__toggle:focus-visible {
-  outline: 2px solid rgba(0, 74, 173, 0.45);
-  outline-offset: 2px;
-}
-
-.secondary-nav__toggle:hover {
-  background: #003b89;
-  transform: translateY(-1px);
-}
-
-.secondary-nav__menu {
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: 22px;
-  width: 100%;
-  justify-content: space-between;
-}
-
-.nav-item {
-  position: relative;
-  flex: 1 1 auto;
-  display: flex;
-  justify-content: center;
-}
-
-.nav-link {
-  width: 100%;
   background: transparent;
   border: none;
   color: #1b1b1b;
-  font-size: 0.95rem;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px 16px;
-  border-radius: 12px;
-  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+  gap: 6px;
+  padding: 10px 4px;
+  cursor: pointer;
+  transition: color 0.3s ease;
 }
 
-.nav-link:focus-visible,
-.nav-link:hover,
-.nav-link.nav-link--direct:focus-visible,
-.nav-link.nav-link--direct:hover {
-  background: rgba(0, 74, 173, 0.1);
+.main-nav__link--direct {
+  position: relative;
+  padding: 10px 6px;
+  text-decoration: none;
+}
+
+.main-nav__link--direct::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: #004aad;
+  transition: width 0.3s ease, left 0.3s ease;
+}
+
+.main-nav__link--direct:hover,
+.main-nav__link--direct:focus-visible,
+.main-nav__item--has-dropdown .main-nav__link:hover,
+.main-nav__item--has-dropdown .main-nav__link:focus-visible {
   color: #004aad;
-  box-shadow: 0 8px 20px rgba(0, 74, 173, 0.12);
 }
 
-.nav-link__icon {
-  display: inline-flex;
-  transform: rotate(0deg);
+.main-nav__link--direct:hover::after,
+.main-nav__link--direct:focus-visible::after {
+  width: 100%;
+  left: 0;
+}
+
+.main-nav__icon {
+  font-size: 0.8rem;
   transition: transform 0.3s ease;
 }
 
-.nav-item.is-open .nav-link__icon {
+.main-nav__item.is-open .main-nav__icon {
   transform: rotate(180deg);
 }
 
-.nav-link.nav-link--direct {
-  text-decoration: none;
-}
-
-.dropdown-menu {
+.main-nav__dropdown {
   position: absolute;
   left: 50%;
-  top: calc(100% + 12px);
-  transform: translate(-50%, 10px);
-  background: #fff;
+  top: calc(100% + 8px);
+  transform: translate(-50%, 12px);
+  background: #ffffff;
   border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
   padding: 18px 22px;
-  box-shadow: 0 15px 35px rgba(15, 35, 95, 0.12);
   opacity: 0;
   pointer-events: none;
-  min-width: 200px;
-  transition: opacity 0.25s ease, transform 0.25s ease;
-  z-index: 20;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  min-width: 220px;
+  z-index: 10;
 }
 
-.nav-item.is-open .dropdown-menu {
+.main-nav__item.is-open .main-nav__dropdown {
   opacity: 1;
-  transform: translate(-50%, 0px);
+  transform: translate(-50%, 0);
   pointer-events: auto;
 }
 
-.dropdown-menu--grid {
+.main-nav__dropdown--columns {
   display: grid;
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  grid-template-columns: repeat(2, minmax(160px, 1fr));
   gap: 24px;
-  min-width: 360px;
+  min-width: 420px;
 }
 
-.dropdown-section__title {
+.main-nav__column-title {
   font-size: 0.85rem;
+  font-weight: 600;
+  color: #004aad;
   text-transform: uppercase;
-  color: #6b7a99;
-  margin-bottom: 10px;
-  letter-spacing: 0.08em;
+  margin-bottom: 8px;
 }
 
-.dropdown-list {
+.main-nav__list {
   list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
-.dropdown-link {
-  display: flex;
+.main-nav__dropdown-link {
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
+  gap: 6px;
   color: #1b1b1b;
   text-decoration: none;
   font-size: 0.9rem;
-  background: transparent;
-  border: none;
-  padding: 6px 0;
-  cursor: pointer;
-  font-family: inherit;
-  text-align: left;
+  transition: color 0.3s ease;
+  padding: 4px 0;
 }
 
-.dropdown-link:hover,
-.dropdown-link:focus-visible {
-  color: #004aad;
-}
-
-.dropdown-link::before {
-  content: '•';
-  color: rgba(0, 74, 173, 0.4);
-  font-size: 0.8rem;
-  display: inline-flex;
-}
-
-.dropdown-link--faq::before {
-  content: '❓';
-  font-size: 0.9rem;
-  color: rgba(0, 74, 173, 0.6);
-}
-
-.secondary-nav__menu--open {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  width: 100%;
-}
-
-.nav-item--has-dropdown .dropdown-menu {
-  text-align: left;
-}
-
-.nav-item--has-dropdown .dropdown-menu::before {
+.main-nav__dropdown-link::before {
   content: '';
-  position: absolute;
-  top: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 18px;
-  height: 18px;
-  background: #fff;
-  border-radius: 4px;
-  box-shadow: -4px -4px 12px rgba(15, 35, 95, 0.04);
-  clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(0, 74, 173, 0.35);
+  display: inline-block;
 }
 
-.header-categories {
-  border-top: 1px solid #e6e6e6;
-  overflow: hidden;
-  max-height: var(--categories-height, 60px);
-  opacity: 1;
-  background: #fff;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
-}
-
-.header-categories ul {
-  display: flex;
-  justify-content: center;
-  list-style: none;
-  gap: 30px;
-  padding: 12px 0;
-}
-
-.header-categories a {
-  text-decoration: none;
-  color: #333;
-  font-weight: 500;
-  font-size: 0.95rem;
-  padding-bottom: 2px;
-  border-bottom: 2px solid transparent;
-  transition: color 0.2s ease, border-color 0.2s ease;
-}
-
-.header-categories a:hover {
+.main-nav__dropdown-link:hover,
+.main-nav__dropdown-link:focus-visible {
   color: #004aad;
-  border-color: #004aad;
+  text-decoration: underline;
 }
 
-.main-header.header--scrolled .header-categories {
+.site-header__bottom--collapsed {
   max-height: 0;
   opacity: 0;
   pointer-events: none;
 }
 
-.main-header.header--scrolled .header-categories ul {
-  padding-top: 0;
-  padding-bottom: 0;
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (max-width: 1024px) {
-  .nav-link {
-    font-size: 0.9rem;
-    padding: 10px 12px;
+  .site-header__top {
+    flex-wrap: wrap;
+    gap: 16px;
   }
 
-  .dropdown-menu {
-    min-width: 180px;
+  .site-header__search {
+    order: 3;
+    width: 100%;
+    max-width: none;
   }
 
-  .dropdown-menu--grid {
+  .site-header__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .main-nav {
+    gap: 18px;
+  }
+
+  .main-nav__dropdown--columns {
     grid-template-columns: 1fr;
     min-width: 260px;
   }
 }
 
-@media (max-width: 900px) {
-  .secondary-nav {
-    padding: 10px;
+@media (max-width: 768px) {
+  .site-header__top {
+    align-items: flex-start;
   }
 
-  .secondary-nav__inner {
-    align-items: stretch;
+  .site-header__actions {
+    justify-content: center;
+    gap: 16px;
   }
 
-  .secondary-nav__toggle {
-    display: inline-flex;
+  .main-nav {
+    flex-wrap: wrap;
+    row-gap: 12px;
   }
 
-  .secondary-nav__menu {
-    display: none;
-    flex-direction: column;
-    width: 100%;
-  }
-
-  .secondary-nav__menu--open {
-    display: flex;
-  }
-
-  .nav-item {
-    justify-content: flex-start;
-  }
-
-  .nav-link {
-    justify-content: space-between;
-  }
-
-  .dropdown-menu {
+  .main-nav__dropdown {
     position: static;
     transform: translate(0, 0);
-    box-shadow: none;
-    border: 1px solid rgba(0, 74, 173, 0.08);
-    margin-top: 10px;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    margin-top: 8px;
+  }
+
+  .main-nav__item.is-open .main-nav__dropdown {
     opacity: 1;
-    pointer-events: auto;
-    display: none;
-  }
-
-  .nav-item.is-open .dropdown-menu {
-    display: block;
-  }
-
-  .nav-item--has-dropdown .dropdown-menu::before {
-    display: none;
   }
 }
 
-@media (max-width: 600px) {
-  .secondary-nav {
-    border-radius: 14px;
+@media (max-width: 540px) {
+  .site-header__top {
+    padding: 16px 0;
   }
 
-  .secondary-nav__toggle {
-    width: 100%;
+  .site-header__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .site-header__action {
     justify-content: center;
   }
 
-  .nav-link {
-    font-size: 0.95rem;
+  .main-nav {
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- restructure the header into a sticky two-row layout with logo, search, account/cart actions, and category navigation
- restyle the header elements to match the requested palette, rounded controls, and hover animations
- replace the dropdown and scroll behavior scripts to support hover interactions and hide the category bar on downward scroll

## Testing
- Manual QA: opened Frontend/index.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68dbfbb34260832e88a8e90dea84ff5f