### PR TITLE
Improve mobile header and navigation responsiveness

### DIFF
--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -468,31 +468,53 @@ body {
     order: 4;
     flex-basis: 100%;
     position: relative;
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 8px;
     width: 100%;
     max-width: none;
-    margin: 10px 0 0;
+    margin: 0;
     padding: 0;
     background: transparent;
     border: none;
+    border-radius: 999px;
     transform: none;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition: max-height 0.35s ease, opacity 0.25s ease, margin 0.25s ease, padding 0.25s ease, border 0.25s ease;
+  }
+
+  .site-header.is-search-open .site-header__search {
+    margin-top: 12px;
+    padding: 4px 12px;
+    border: 1px solid #cdcdcd;
+    background: #ffffff;
+    max-height: 72px;
+    opacity: 1;
+    visibility: visible;
   }
 
   .site-header__search input {
-    width: 100%;
-    height: 44px;
-    padding: 0 44px 0 16px;
-    border: 1px solid #cdcdcd;
+    flex: 1 1 clamp(140px, 70vw, 520px);
+    min-width: 0;
+    width: auto;
+    height: 40px;
+    padding: 0 12px;
+    border: none;
     border-radius: 999px;
-    background: #ffffff;
+    background: transparent;
     font-size: 0.95rem;
   }
 
+  .site-header.is-search-open .site-header__search input {
+    background: #ffffff;
+  }
+
   .site-header__search button {
-    position: absolute;
-    top: 50%;
-    right: 16px;
-    transform: translateY(-50%);
+    position: static;
+    transform: none;
     margin-left: 0;
     background: none;
     border: none;
@@ -501,9 +523,7 @@ body {
 
   .site-header__search button:hover,
   .site-header__search button:focus-visible {
-    background: none;
     color: #004aad;
-    transform: translateY(-50%);
   }
 
   .main-nav {
@@ -1057,57 +1077,27 @@ body {
     display: inline-flex; /* aparece en mobile */
   }
 
-  /* Ocultamos categorías de la barra principal */
   .site-header__bottom {
-    display: none;
+    display: block;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: max-height 0.35s ease, opacity 0.25s ease, transform 0.25s ease;
+  }
+
+  .site-header__bottom.is-open {
+    max-height: 600px;
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
   }
 }
 
-/* ==== Menú lateral ==== */
+/* ==== Menú lateral (overlay) ==== */
 .mobile-menu {
-  position: fixed;
-  top: 0;
-  left: -100%; /* oculto por defecto */
-  width: 80%;
-  height: 100%;
-  background: #111;
-  color: #fff;
-  padding: 20px;
-  transition: left 0.3s ease;
-  z-index: 2000;
-}
-
-.mobile-menu.active {
-  left: 0;
-}
-
-.menu-close {
-  background: none;
-  border: none;
-  font-size: 1.8rem;
-  color: #fff;
-  cursor: pointer;
-  margin-bottom: 20px;
-}
-
-.mobile-nav ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.mobile-nav a {
-  text-decoration: none;
-  color: #fff;
-  font-size: 1.1rem;
-  font-weight: 500;
-}
-
-.mobile-nav a:hover {
-  color: #004aad;
+  display: none;
 }
 
 /* Botón de búsqueda (oculto en desktop) */

--- a/Frontend/javaScript/main.js
+++ b/Frontend/javaScript/main.js
@@ -122,29 +122,100 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   });
-});
 
-
-document.addEventListener("DOMContentLoaded", () => {
+  /* ===========================
+     🔹 Interacciones Mobile (menú & buscador)
+  =========================== */
+  const siteHeader = document.querySelector(".site-header");
   const menuToggle = document.querySelector(".menu-toggle");
-  const mobileMenu = document.getElementById("mobileMenu");
-  const menuClose = document.querySelector(".menu-close");
-
-  menuToggle.addEventListener("click", () => {
-    mobileMenu.classList.add("active");
-  });
-
-  menuClose.addEventListener("click", () => {
-    mobileMenu.classList.remove("active");
-  });
-});
-
-document.addEventListener("DOMContentLoaded", () => {
+  const mainNav = document.querySelector(".site-header__bottom");
   const searchToggle = document.querySelector(".search-toggle");
   const searchForm = document.querySelector(".site-header__search");
+  const searchIcon = searchToggle ? searchToggle.querySelector("i") : null;
 
-  searchToggle.addEventListener("click", () => {
-    searchForm.style.display = "flex"; // muestra el buscador
-    searchForm.querySelector("input").focus();
-  });
+  if (searchToggle) {
+    searchToggle.setAttribute("aria-expanded", "false");
+    searchToggle.setAttribute("aria-label", "Abrir buscador");
+  }
+
+  const setSearchIcon = (isOpen) => {
+    if (!searchIcon) return;
+    if (isOpen) {
+      searchIcon.classList.remove("fa-magnifying-glass");
+      searchIcon.classList.add("fa-xmark");
+    } else {
+      searchIcon.classList.remove("fa-xmark");
+      searchIcon.classList.add("fa-magnifying-glass");
+    }
+  };
+
+  const closeSearch = () => {
+    if (!siteHeader) return;
+    if (siteHeader.classList.contains("is-search-open")) {
+      siteHeader.classList.remove("is-search-open");
+      setSearchIcon(false);
+      if (searchToggle) {
+        searchToggle.setAttribute("aria-expanded", "false");
+        searchToggle.setAttribute("aria-label", "Abrir buscador");
+      }
+    }
+  };
+
+  const closeMenu = () => {
+    if (!mainNav) return;
+    mainNav.classList.remove("is-open");
+    siteHeader?.classList.remove("is-menu-open");
+    if (menuToggle) {
+      menuToggle.setAttribute("aria-expanded", "false");
+    }
+  };
+
+  const handleResize = () => {
+    if (window.innerWidth >= 768) {
+      closeSearch();
+      closeMenu();
+      if (searchToggle) {
+        searchToggle.setAttribute("aria-expanded", "false");
+        searchToggle.setAttribute("aria-label", "Abrir buscador");
+      }
+    }
+  };
+
+  if (menuToggle && mainNav) {
+    menuToggle.addEventListener("click", () => {
+      const willOpen = !mainNav.classList.contains("is-open");
+      if (willOpen) {
+        closeSearch();
+      }
+      mainNav.classList.toggle("is-open", willOpen);
+      siteHeader?.classList.toggle("is-menu-open", willOpen);
+      menuToggle.setAttribute("aria-expanded", String(willOpen));
+    });
+  }
+
+  if (searchToggle && searchForm && siteHeader) {
+    searchToggle.addEventListener("click", (event) => {
+      event.preventDefault();
+      if (window.innerWidth >= 768) return;
+
+      const willOpen = !siteHeader.classList.contains("is-search-open");
+      if (willOpen) {
+        closeMenu();
+      }
+      siteHeader.classList.toggle("is-search-open", willOpen);
+      setSearchIcon(willOpen);
+      searchToggle.setAttribute("aria-expanded", String(willOpen));
+      searchToggle.setAttribute("aria-label", willOpen ? "Cerrar buscador" : "Abrir buscador");
+
+      if (willOpen) {
+        window.requestAnimationFrame(() => {
+          const input = searchForm.querySelector("input");
+          input?.focus();
+        });
+      }
+    });
+  }
+
+  window.addEventListener("resize", handleResize);
+  handleResize();
 });


### PR DESCRIPTION
## Summary
- adjust the mobile header so the search bar collapses under the header, resizes fluidly, and toggles between search/close icons
- replace the mobile hamburger overlay with a slide-down navigation panel that pushes page content instead of covering it
- update the JavaScript interactions to coordinate mobile menu and search behaviour with accessibility attributes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de894c2cbc832e8c91fb3788c340aa