### PR TITLE
Enhance mobile search overlay and account dropdown

### DIFF
--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -163,6 +163,10 @@ body {
   z-index: 1999;      /* 👈 más alto que el hero */
 }
 
+.mobile-search-overlay {
+  display: none;
+}
+
 /* Dropdown en Mi cuenta */
 .site-header__action--has-dropdown {
   position: relative;
@@ -1099,6 +1103,48 @@ body {
   }
 }
 
+@media (max-width: 768px) {
+  .modal.active {
+    align-items: flex-start;
+    padding-top: 60px;
+    padding-bottom: 40px;
+  }
+
+  .modal-content {
+    margin: 0 16px;
+    width: calc(100% - 32px);
+    max-width: 100%;
+    padding: 28px 20px;
+    border-radius: 14px;
+  }
+
+  .modal-content h2 {
+    font-size: 1.25rem;
+    text-align: center;
+  }
+
+  .form-footer {
+    text-align: left;
+  }
+
+  .form-register .two-columns {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .form-register .two-columns > div {
+    width: 100%;
+  }
+
+  .modal-content .btn.btn--primary {
+    width: 100%;
+  }
+
+  .password-field .toggle-password {
+    top: 50%;
+  }
+}
+
 @media (max-width: 540px) {
   .footer-inner {
     grid-template-columns: 1fr; 
@@ -1213,7 +1259,7 @@ body {
   .site-header__action--has-dropdown {
     order: 3; /* tercero la cuenta */
   }
-  
+
   .site-header__action--has-dropdown .site-header__action-label {
     display: none;
   }
@@ -1221,6 +1267,101 @@ body {
   /* Carrito solo ícono */
   #link-carrito .site-header__action-label {
     display: none;
+  }
+
+  .mobile-search-overlay {
+    display: flex;
+    position: fixed;
+    top: var(--mobile-search-top, 72px);
+    left: 0;
+    right: 0;
+    padding: 12px 16px;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-10px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 4000;
+  }
+
+  .mobile-search-overlay.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .mobile-search-form {
+    flex: 1;
+    max-width: 600px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #ffffff;
+    border: 1px solid #cdcdcd;
+    border-radius: 15px;
+    padding: 2px 12px;
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.15);
+  }
+
+  .mobile-search-form input {
+    flex: 1;
+    border: none;
+    padding: 10px 6px;
+    font-size: 0.95rem;
+    background: transparent;
+  }
+
+  .mobile-search-form input:focus {
+    outline: none;
+  }
+
+  .mobile-search-form button {
+    background: none;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #868686;
+    font-size: 1.2rem;
+    cursor: pointer;
+  }
+
+  .mobile-search-form button .material-symbols-outlined {
+    font-size: 22px;
+  }
+
+  .mobile-search-form button .fa-solid {
+    font-size: 18px;
+  }
+
+  .site-header__action--has-dropdown .site-header__dropdown {
+    position: fixed;
+    top: var(--mobile-account-top, 72px);
+    right: 16px;
+    left: auto;
+    max-width: calc(100% - 32px);
+    transform: translateY(-12px);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.18);
+    border-radius: 14px;
+    padding: 16px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 3500;
+  }
+
+  .site-header__action--has-dropdown.is-open .site-header__dropdown {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .site-header__action--has-dropdown .site-header__dropdown-list {
+    gap: 14px;
+  }
+
+  .site-header__action--has-dropdown .site-header__dropdown-list a {
+    font-size: 1rem;
   }
 }
 

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -159,7 +159,16 @@
 </nav>
 
 
-</header>
+<!-- Buscador flotante para mobile -->
+<div class="mobile-search-overlay" aria-hidden="true">
+  <form class="mobile-search-form" role="search" aria-label="Buscador de productos">
+    <label class="visually-hidden" for="mobile-search-input">Buscar en Vesper</label>
+    <input type="search" id="mobile-search-input" name="mobile-search" placeholder="Buscá por productos, marcas y categorías" autocomplete="off">
+    <button type="submit" aria-label="Buscar">
+      <span class="material-symbols-outlined" aria-hidden="true">search</span>
+    </button>
+  </form>
+</div>
 
 <!-- Menú lateral oculto -->
 <aside class="mobile-menu" id="mobileMenu">

--- a/Frontend/javaScript/main.js
+++ b/Frontend/javaScript/main.js
@@ -28,25 +28,6 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   /* ===========================
-     🔹 Dropdown "Mi cuenta"
-  =========================== */
-  const accountDropdown = document.querySelector(".site-header__action--has-dropdown");
-  if (accountDropdown) {
-    const accountBtn = accountDropdown.querySelector(".site-header__action-btn");
-
-    accountBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      accountDropdown.classList.toggle("is-open");
-    });
-
-    document.addEventListener("click", (e) => {
-      if (!accountDropdown.contains(e.target)) {
-        accountDropdown.classList.remove("is-open");
-      }
-    });
-  }
-
-  /* ===========================
      🔹 Modales (Login / Register)
   =========================== */
   const modalLogin = document.getElementById("modal-login");
@@ -130,59 +111,117 @@ document.addEventListener("DOMContentLoaded", () => {
   const menuToggle = document.querySelector(".menu-toggle");
   const mainNav = document.querySelector(".site-header__bottom");
   const searchToggle = document.querySelector(".search-toggle");
-  const searchForm = document.querySelector(".site-header__search");
-  const searchIcon = searchToggle ? searchToggle.querySelector("i") : null;
+  const desktopSearchForm = document.querySelector(".site-header__search");
+  const desktopSearchButton = desktopSearchForm?.querySelector("button");
+  const mobileSearchOverlay = document.querySelector(".mobile-search-overlay");
+  const mobileSearchInput = mobileSearchOverlay?.querySelector("input");
+  const overlaySearchButton = mobileSearchOverlay?.querySelector("button");
+  const accountDropdown = document.querySelector(".site-header__action--has-dropdown");
+  const accountBtn = accountDropdown?.querySelector(".site-header__action-btn");
+  const searchIconMaterial = searchToggle ? searchToggle.querySelector(".material-symbols-outlined") : null;
+  const searchIconFontAwesome = searchToggle ? searchToggle.querySelector(".fa-solid") : null;
+
+  if (overlaySearchButton && desktopSearchButton && desktopSearchButton.innerHTML.trim()) {
+    overlaySearchButton.innerHTML = desktopSearchButton.innerHTML;
+  }
+
+  if (mobileSearchOverlay) {
+    mobileSearchOverlay.setAttribute("aria-hidden", "true");
+  }
 
   if (searchToggle) {
     searchToggle.setAttribute("aria-expanded", "false");
     searchToggle.setAttribute("aria-label", "Abrir buscador");
   }
 
-  const setSearchIcon = (isOpen) => {
-    if (!searchIcon) return;
-    if (isOpen) {
-      searchIcon.classList.remove("fa-magnifying-glass");
-      searchIcon.classList.add("fa-xmark");
-    } else {
-      searchIcon.classList.remove("fa-xmark");
-      searchIcon.classList.add("fa-magnifying-glass");
+  function setSearchIcon(isOpen) {
+    if (searchIconMaterial) {
+      searchIconMaterial.textContent = isOpen ? "close" : "search";
     }
-  };
-
-  const closeSearch = () => {
-    if (!siteHeader) return;
-    if (siteHeader.classList.contains("is-search-open")) {
-      siteHeader.classList.remove("is-search-open");
-      setSearchIcon(false);
-      if (searchToggle) {
-        searchToggle.setAttribute("aria-expanded", "false");
-        searchToggle.setAttribute("aria-label", "Abrir buscador");
-      }
+    if (searchIconFontAwesome) {
+      searchIconFontAwesome.classList.toggle("fa-magnifying-glass", !isOpen);
+      searchIconFontAwesome.classList.toggle("fa-xmark", isOpen);
     }
-  };
-
-    const closeMenu = () => {
-  if (!mainNav) return;
-  mainNav.classList.remove("is-open");
-  siteHeader?.classList.remove("is-menu-open");
-  if (menuToggle) {
-    menuToggle.setAttribute("aria-expanded", "false");
   }
 
-  // 🔹 Cerrar también todos los submenús abiertos
-  document.querySelectorAll(".main-nav__item--has-dropdown").forEach(item => {
-    item.classList.remove("is-open");
-  });
-  };
+  function updateSearchOverlayPosition() {
+    if (!mobileSearchOverlay) return;
+    const headerRect = siteHeader?.getBoundingClientRect();
+    if (headerRect) {
+      mobileSearchOverlay.style.setProperty("--mobile-search-top", `${Math.max(headerRect.bottom, 0)}px`);
+    }
+  }
 
+  function updateAccountMenuPosition() {
+    if (!accountDropdown) return;
+    const headerRect = siteHeader?.getBoundingClientRect();
+    if (headerRect) {
+      accountDropdown.style.setProperty("--mobile-account-top", `${Math.max(headerRect.bottom, 0)}px`);
+    }
+  }
+
+  function openSearch() {
+    if (mobileSearchOverlay) {
+      updateSearchOverlayPosition();
+      mobileSearchOverlay.classList.add("is-visible");
+      mobileSearchOverlay.setAttribute("aria-hidden", "false");
+    }
+    siteHeader?.classList.add("is-search-open");
+    setSearchIcon(true);
+    if (searchToggle) {
+      searchToggle.setAttribute("aria-expanded", "true");
+      searchToggle.setAttribute("aria-label", "Cerrar buscador");
+    }
+    window.requestAnimationFrame(() => {
+      mobileSearchInput?.focus();
+    });
+  }
+
+  function closeSearch() {
+    if (mobileSearchOverlay) {
+      mobileSearchOverlay.classList.remove("is-visible");
+      mobileSearchOverlay.setAttribute("aria-hidden", "true");
+    }
+    siteHeader?.classList.remove("is-search-open");
+    setSearchIcon(false);
+    if (searchToggle) {
+      searchToggle.setAttribute("aria-expanded", "false");
+      searchToggle.setAttribute("aria-label", "Abrir buscador");
+    }
+    if (mobileSearchInput) {
+      mobileSearchInput.value = "";
+    }
+  }
+
+  function closeMenu() {
+    if (!mainNav) return;
+    mainNav.classList.remove("is-open");
+    siteHeader?.classList.remove("is-menu-open");
+    if (menuToggle) {
+      menuToggle.setAttribute("aria-expanded", "false");
+    }
+
+    document.querySelectorAll(".main-nav__item--has-dropdown").forEach(item => {
+      item.classList.remove("is-open");
+    });
+  }
+
+  function closeAccountDropdown() {
+    if (!accountDropdown) return;
+    accountDropdown.classList.remove("is-open");
+  }
 
   const handleResize = () => {
     if (window.innerWidth >= 768) {
       closeSearch();
       closeMenu();
-      if (searchToggle) {
-        searchToggle.setAttribute("aria-expanded", "false");
-        searchToggle.setAttribute("aria-label", "Abrir buscador");
+      closeAccountDropdown();
+    } else {
+      if (mobileSearchOverlay?.classList.contains("is-visible")) {
+        updateSearchOverlayPosition();
+      }
+      if (accountDropdown?.classList.contains("is-open")) {
+        updateAccountMenuPosition();
       }
     }
   };
@@ -192,6 +231,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const willOpen = !mainNav.classList.contains("is-open");
       if (willOpen) {
         closeSearch();
+        closeAccountDropdown();
       }
       mainNav.classList.toggle("is-open", willOpen);
       siteHeader?.classList.toggle("is-menu-open", willOpen);
@@ -200,43 +240,97 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   /* ===========================
-   🔹 Submenús en mobile (acordeón)
-=========================== */
-const navItems = document.querySelectorAll(".main-nav__item--has-dropdown");
+     🔹 Submenús en mobile (acordeón)
+  =========================== */
+  const navItems = document.querySelectorAll(".main-nav__item--has-dropdown");
 
-navItems.forEach(item => {
-  const link = item.querySelector(".main-nav__link");
+  navItems.forEach(item => {
+    const link = item.querySelector(".main-nav__link");
+    if (!link) return;
 
-  link.addEventListener("click", (e) => {
-    if (window.innerWidth < 768) {
-      e.preventDefault(); // evita navegación directa
-      item.classList.toggle("is-open");
-    }
+    link.addEventListener("click", (e) => {
+      if (window.innerWidth < 768) {
+        e.preventDefault();
+        item.classList.toggle("is-open");
+      }
+    });
   });
-});
 
-  if (searchToggle && searchForm && siteHeader) {
+  if (searchToggle) {
     searchToggle.addEventListener("click", (event) => {
       event.preventDefault();
       if (window.innerWidth >= 768) return;
 
-      const willOpen = !siteHeader.classList.contains("is-search-open");
-      if (willOpen) {
-        closeMenu();
-      }
-      siteHeader.classList.toggle("is-search-open", willOpen);
-      setSearchIcon(willOpen);
-      searchToggle.setAttribute("aria-expanded", String(willOpen));
-      searchToggle.setAttribute("aria-label", willOpen ? "Cerrar buscador" : "Abrir buscador");
+      const isOverlayVisible = mobileSearchOverlay?.classList.contains("is-visible") ?? siteHeader?.classList.contains("is-search-open");
+      const willOpen = !isOverlayVisible;
 
       if (willOpen) {
-        window.requestAnimationFrame(() => {
-          const input = searchForm.querySelector("input");
-          input?.focus();
-        });
+        closeMenu();
+        closeAccountDropdown();
+        openSearch();
+      } else {
+        closeSearch();
       }
     });
   }
+
+  if (accountBtn && accountDropdown) {
+    accountBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const willOpen = !accountDropdown.classList.contains("is-open");
+      if (willOpen) {
+        closeMenu();
+        closeSearch();
+        updateAccountMenuPosition();
+      }
+      accountDropdown.classList.toggle("is-open", willOpen);
+    });
+  }
+
+  if (accountDropdown) {
+    accountDropdown.querySelectorAll("a").forEach(link => {
+      link.addEventListener("click", () => {
+        closeAccountDropdown();
+      });
+    });
+  }
+
+  document.addEventListener("click", (event) => {
+    if (accountDropdown && !accountDropdown.contains(event.target)) {
+      closeAccountDropdown();
+    }
+
+    if (mobileSearchOverlay?.classList.contains("is-visible")) {
+      const clickedInsideSearch = mobileSearchOverlay.contains(event.target);
+      const clickedToggle = searchToggle?.contains(event.target) ?? false;
+      if (!clickedInsideSearch && !clickedToggle) {
+        closeSearch();
+      }
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeSearch();
+      closeAccountDropdown();
+      if (window.innerWidth < 768) {
+        closeMenu();
+      }
+    }
+  });
+
+  window.addEventListener("scroll", () => {
+    if (window.innerWidth >= 768) return;
+
+    if (mobileSearchOverlay?.classList.contains("is-visible")) {
+      updateSearchOverlayPosition();
+    }
+    if (accountDropdown?.classList.contains("is-open")) {
+      updateAccountMenuPosition();
+    }
+  }, { passive: true });
 
   window.addEventListener("resize", handleResize);
   handleResize();

--- a/Frontend/productos.html
+++ b/Frontend/productos.html
@@ -139,7 +139,17 @@
     </ul>
   </div>
 </nav>
-  </header>
+
+  <!-- Buscador flotante para mobile -->
+  <div class="mobile-search-overlay" aria-hidden="true">
+    <form class="mobile-search-form" role="search" aria-label="Buscador de productos">
+      <label class="visually-hidden" for="mobile-search-input">Buscar en Vesper</label>
+      <input type="search" id="mobile-search-input" name="mobile-search" placeholder="Buscá por productos, marcas y categorías" autocomplete="off">
+      <button type="submit" aria-label="Buscar">
+        <span class="material-symbols-outlined" aria-hidden="true">search</span>
+      </button>
+    </form>
+  </div>
 
   <!-- Contenido principal -->
   <main class="container productos-page">


### PR DESCRIPTION
## Summary
- add a floating mobile search overlay with toggleable icon and consistent styling
- refine the mobile "Mi cuenta" dropdown positioning and make login/register modals responsive
- update mobile scripting to coordinate search, menu, and account interactions across breakpoints

## Testing
- Manual QA on index.html (mobile viewport)


------
https://chatgpt.com/codex/tasks/task_e_68deee66f23c832e941a18bcc2dcdc6b