### PR TITLE
Add cart modal with shipping calculator and toasts

### DIFF
--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -1523,6 +1523,7 @@ body.is-cart-open {
   right: var(--toast-right, 20px);
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: 12px;
   z-index: 8500;
   pointer-events: none;
@@ -1541,6 +1542,15 @@ body.is-cart-open {
   max-width: 260px;
 }
 
+.cart-toast__label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+  color: rgba(226, 232, 240, 0.9);
+}
+
 .cart-toast strong {
   display: block;
   font-size: 0.95rem;
@@ -1557,18 +1567,22 @@ body.is-cart-open {
   transform: translateY(0);
 }
 
-@media (max-width: 600px) {
-  .cart-toast-layer {
-    left: 0;
-    right: 0;
-    top: auto;
-    bottom: 20px;
-    align-items: center;
-  }
+.cart-toast-layer--mobile {
+  left: 0;
+  right: 0;
+  top: auto;
+  bottom: 24px;
+  padding: 0 16px;
+  align-items: center;
+}
 
-  .cart-toast {
-    width: min(90vw, 320px);
-  }
+.cart-toast-layer--mobile .cart-toast {
+  width: min(90vw, 360px);
+  transform: translateY(12px);
+}
+
+.cart-toast-layer--mobile .cart-toast.is-visible {
+  transform: translateY(0);
 }
 
 .form-group {

--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -848,6 +848,21 @@ body {
   font-weight: 600;
 }
 
+.product-subtitle {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin-bottom: 10px;
+  font-weight: 400;
+}
+
+.product-pricing {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+
 .price {
   color: #004aad;
   font-weight: bold;
@@ -861,11 +876,21 @@ body {
 
 /* Botón de Productos Destacados */
 .featured-products .btn.btn--primary {
-  width: auto;           
-  padding: 10px 20px;    
-  font-size: 0.95rem;    
+  width: auto;
+  padding: 10px 20px;
+  font-size: 0.95rem;
   border-radius: 6px;
   margin-top: 20px;
+}
+
+.product .product__add {
+  width: 100%;
+  margin-top: 4px;
+  padding: 12px 16px;
+}
+
+.product .product__add:hover {
+  transform: translateY(-1px);
 }
 
 .btn.btn--primary:hover {
@@ -1041,6 +1066,509 @@ body {
   font-weight: 600;
   margin-bottom: 6px;
   color: #1b1b1b;
+}
+
+/* =======================
+   Carrito de compras (modal)
+======================= */
+.site-header__action-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cart-count-badge {
+  position: absolute;
+  top: -6px;
+  right: -10px;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #1b1b1b;
+  font-size: 0.7rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #cbd5f5;
+}
+
+body.is-cart-open {
+  overflow: hidden;
+}
+
+.cart-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 8000;
+}
+
+.cart-modal.is-open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.cart-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.cart-modal.is-open .cart-modal__overlay {
+  opacity: 1;
+}
+
+.cart-modal__panel {
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  height: 100vh;
+  background: #fff;
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+  box-shadow: -18px 0 40px rgba(15, 23, 42, 0.16);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.cart-modal.is-open .cart-modal__panel {
+  transform: translateX(0);
+}
+
+@media (min-width: 768px) {
+  .cart-modal__panel {
+    width: min(420px, 85vw);
+  }
+}
+
+@media (min-width: 1200px) {
+  .cart-modal__panel {
+    width: min(460px, 36vw);
+  }
+}
+
+.cart-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 24px 28px 16px;
+  gap: 16px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.cart-modal__header h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.cart-modal__subtitle {
+  font-size: 0.9rem;
+  color: #64748b;
+  margin-top: 4px;
+}
+
+.cart-modal__close {
+  border: none;
+  background: rgba(226, 232, 240, 0.6);
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: #1f2937;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.cart-modal__close:hover {
+  background: rgba(148, 163, 184, 0.35);
+  transform: translateY(-1px);
+}
+
+.cart-modal__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cart-empty-state {
+  display: none;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 12px;
+  text-align: center;
+  padding: 40px 20px;
+  color: #1f2937;
+}
+
+.cart-empty-state.is-visible {
+  display: flex;
+}
+
+.cart-empty-state__icon {
+  font-size: 3rem;
+  color: #004aad;
+}
+
+.cart-empty-state p {
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.cart-empty-state .btn {
+  width: auto;
+  padding: 12px 26px;
+}
+
+.cart-items {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.cart-item {
+  position: relative;
+  display: flex;
+  gap: 16px;
+  background: #f8fafc;
+  border-radius: 18px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.cart-item__remove {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  border: none;
+  background: transparent;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.cart-item__media img {
+  width: 84px;
+  height: 84px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.cart-item__info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cart-item__info h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.cart-item__subtitle {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.cart-item__prices {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.cart-item__price-original {
+  text-decoration: line-through;
+  color: #9ca3af;
+  font-size: 0.9rem;
+}
+
+.cart-item__price {
+  font-weight: 600;
+  color: #004aad;
+  font-size: 1rem;
+}
+
+.cart-item__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cart-item__quantity {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  padding: 4px 8px;
+}
+
+.cart-item__qty-btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: #fff;
+  font-size: 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cart-item__qty-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.18);
+}
+
+.cart-item__qty-value {
+  min-width: 24px;
+  text-align: center;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.cart-item__total {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+@media (max-width: 520px) {
+  .cart-item {
+    flex-direction: column;
+    padding-right: 20px;
+  }
+
+  .cart-item__remove {
+    top: 8px;
+    right: 8px;
+  }
+
+  .cart-item__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cart-item__total {
+    align-self: flex-end;
+  }
+}
+
+.shipping-section {
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 18px;
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shipping-section.is-visible {
+  display: flex;
+}
+
+.shipping-section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.shipping-form {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.shipping-form input {
+  flex: 1 1 180px;
+  border: 1px solid rgba(148, 163, 184, 0.7);
+  border-radius: 14px;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+}
+
+.shipping-form input:focus {
+  outline: none;
+  border-color: #004aad;
+  box-shadow: 0 0 0 2px rgba(0, 74, 173, 0.12);
+}
+
+.shipping-form button {
+  background: #0f172a;
+  color: #fff;
+  border: none;
+  padding: 12px 22px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  border-radius: 14px;
+  cursor: pointer;
+  text-transform: uppercase;
+  flex: 0 0 auto;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.shipping-form button:hover {
+  background: #1e293b;
+  transform: translateY(-1px);
+}
+
+.shipping-result {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.summary-section {
+  padding: 20px 28px 28px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  background: #f8fafc;
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-section.is-visible {
+  display: flex;
+}
+
+.summary-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.summary-line--total span {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.summary-total__label small {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.summary-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-actions .btn {
+  width: 100%;
+}
+
+.summary-actions__primary {
+  background: #d90429;
+}
+
+.summary-actions__primary:hover {
+  background: #b10221;
+}
+
+.summary-actions__secondary {
+  background: transparent;
+  border: 1px solid #004aad;
+  color: #004aad;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.summary-actions__secondary:hover {
+  background: rgba(0, 74, 173, 0.08);
+  color: #003080;
+}
+
+@media (min-width: 520px) {
+  .summary-actions {
+    flex-direction: row;
+  }
+
+  .summary-actions .btn {
+    flex: 1;
+  }
+}
+
+.cart-toast-layer {
+  position: fixed;
+  top: var(--toast-top, 90px);
+  right: var(--toast-right, 20px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 8500;
+  pointer-events: none;
+  padding: 0 20px;
+}
+
+.cart-toast {
+  background: rgba(15, 23, 42, 0.95);
+  color: #fff;
+  padding: 14px 18px;
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  max-width: 260px;
+}
+
+.cart-toast strong {
+  display: block;
+  font-size: 0.95rem;
+  margin-bottom: 4px;
+}
+
+.cart-toast span {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.cart-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 600px) {
+  .cart-toast-layer {
+    left: 0;
+    right: 0;
+    top: auto;
+    bottom: 20px;
+    align-items: center;
+  }
+
+  .cart-toast {
+    width: min(90vw, 320px);
+  }
 }
 
 .form-group {

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -76,9 +76,10 @@
 </div>
 
 
-      <a href="#" class="site-header__action" id="link-carrito">
+      <a href="#" class="site-header__action" id="link-carrito" aria-haspopup="dialog">
   <span class="site-header__action-icon">
     <span class="material-symbols-outlined">shopping_cart</span>
+    <span class="cart-count-badge" id="cart-count" aria-live="polite">0</span>
   </span>
   <span class="site-header__action-label"></span>
 </a>
@@ -396,6 +397,59 @@
 </div>
 
 
+
+<!-- Carrito de compras -->
+<div class="cart-modal" id="cart-modal" aria-hidden="true">
+  <div class="cart-modal__overlay" role="presentation"></div>
+  <aside class="cart-modal__panel" role="dialog" aria-labelledby="cartModalTitle">
+    <header class="cart-modal__header">
+      <div>
+        <h2 id="cartModalTitle">Tu carrito</h2>
+        <p class="cart-modal__subtitle">Revisa tus productos antes de continuar</p>
+      </div>
+      <button class="cart-modal__close" type="button" aria-label="Cerrar carrito">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </header>
+    <div class="cart-modal__body">
+      <div class="cart-empty-state" id="cart-empty-state">
+        <span class="material-symbols-outlined cart-empty-state__icon" aria-hidden="true">shopping_bag</span>
+        <h3>Tu carrito está vacío</h3>
+        <p>Agrega algunos productos para comenzar tu compra</p>
+        <button type="button" class="btn btn--primary cart-empty-state__cta">Seguir Comprando</button>
+      </div>
+      <div class="cart-items" id="cart-items" aria-live="polite"></div>
+      <section class="shipping-section" id="shipping-section" aria-labelledby="shippingTitle">
+        <h3 id="shippingTitle">Medios de envío</h3>
+        <form class="shipping-form" id="shipping-form">
+          <label class="visually-hidden" for="shipping-zip">Código postal</label>
+          <input type="text" id="shipping-zip" name="shippingZip" placeholder="Tu código postal" inputmode="numeric" autocomplete="postal-code">
+          <button type="submit">CALCULAR</button>
+        </form>
+        <p class="shipping-result" id="shipping-result" aria-live="polite"></p>
+      </section>
+    </div>
+    <footer class="summary-section" id="summary-section">
+      <div class="summary-line">
+        <span id="summary-count">0 productos</span>
+        <span id="summary-subtotal">$0</span>
+      </div>
+      <div class="summary-line summary-line--total">
+        <div class="summary-total__label">
+          <span>Total</span>
+          <small id="summary-shipping-note">Envío a calcular</small>
+        </div>
+        <span id="summary-total">$0</span>
+      </div>
+      <div class="summary-actions">
+        <button type="button" class="btn btn--primary summary-actions__primary">Iniciar compra</button>
+        <button type="button" class="btn summary-actions__secondary">Ver más productos</button>
+      </div>
+    </footer>
+  </aside>
+</div>
+
+<div class="cart-toast-layer" aria-live="polite" aria-atomic="true"></div>
 
   <script src="javaScript/main.js"></script>
 </body>

--- a/Frontend/productos.html
+++ b/Frontend/productos.html
@@ -144,9 +144,10 @@
 
 
 
-      <a href="#" class="site-header__action" id="link-carrito">
+      <a href="#" class="site-header__action" id="link-carrito" aria-haspopup="dialog">
   <span class="site-header__action-icon">
     <span class="material-symbols-outlined">shopping_cart</span>
+    <span class="cart-count-badge" id="cart-count" aria-live="polite">0</span>
   </span>
   <span class="site-header__action-label"></span>
 </a>
@@ -315,6 +316,59 @@
       </div>
     </div>
   </footer>
+
+  <!-- Carrito de compras -->
+  <div class="cart-modal" id="cart-modal" aria-hidden="true">
+    <div class="cart-modal__overlay" role="presentation"></div>
+    <aside class="cart-modal__panel" role="dialog" aria-labelledby="cartModalTitle">
+      <header class="cart-modal__header">
+        <div>
+          <h2 id="cartModalTitle">Tu carrito</h2>
+          <p class="cart-modal__subtitle">Revisa tus productos antes de continuar</p>
+        </div>
+        <button class="cart-modal__close" type="button" aria-label="Cerrar carrito">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </header>
+      <div class="cart-modal__body">
+        <div class="cart-empty-state" id="cart-empty-state">
+          <span class="material-symbols-outlined cart-empty-state__icon" aria-hidden="true">shopping_bag</span>
+          <h3>Tu carrito está vacío</h3>
+          <p>Agrega algunos productos para comenzar tu compra</p>
+          <button type="button" class="btn btn--primary cart-empty-state__cta">Seguir Comprando</button>
+        </div>
+        <div class="cart-items" id="cart-items" aria-live="polite"></div>
+        <section class="shipping-section" id="shipping-section" aria-labelledby="shippingTitle">
+          <h3 id="shippingTitle">Medios de envío</h3>
+          <form class="shipping-form" id="shipping-form">
+            <label class="visually-hidden" for="shipping-zip">Código postal</label>
+            <input type="text" id="shipping-zip" name="shippingZip" placeholder="Tu código postal" inputmode="numeric" autocomplete="postal-code">
+            <button type="submit">CALCULAR</button>
+          </form>
+          <p class="shipping-result" id="shipping-result" aria-live="polite"></p>
+        </section>
+      </div>
+      <footer class="summary-section" id="summary-section">
+        <div class="summary-line">
+          <span id="summary-count">0 productos</span>
+          <span id="summary-subtotal">$0</span>
+        </div>
+        <div class="summary-line summary-line--total">
+          <div class="summary-total__label">
+            <span>Total</span>
+            <small id="summary-shipping-note">Envío a calcular</small>
+          </div>
+          <span id="summary-total">$0</span>
+        </div>
+        <div class="summary-actions">
+          <button type="button" class="btn btn--primary summary-actions__primary">Iniciar compra</button>
+          <button type="button" class="btn summary-actions__secondary">Ver más productos</button>
+        </div>
+      </footer>
+    </aside>
+  </div>
+
+  <div class="cart-toast-layer" aria-live="polite" aria-atomic="true"></div>
 
   <!-- Scripts -->
   <script src="../Frontend/javaScript/main.js"></script>


### PR DESCRIPTION
## Summary
- implement a fixed cart modal with empty/filled states, shipping calculator, and purchase summary that adapts to mobile and desktop
- add a cart badge, overlay blur, and toast notifications when items are added or removed from the cart
- render sample product cards with add-to-cart actions to drive the new cart experience across index and product pages

## Testing
- no automated tests were run (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68df1360f8b4832e99f0d045d460317c