### PR TITLE
Add responsive cart modal experience

### DIFF
--- a/Frontend/css/productos.css
+++ b/Frontend/css/productos.css
@@ -139,6 +139,12 @@
   color: #222;
 }
 
+.product .product-subtitle {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin: -4px 0 10px;
+}
+
 .product .price {
   font-size: 1.1rem;
   font-weight: 700;

--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -848,6 +848,12 @@ body {
   font-weight: 600;
 }
 
+.product .product-subtitle {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin: -4px 0 12px;
+}
+
 .price {
   color: #004aad;
   font-weight: bold;
@@ -861,9 +867,9 @@ body {
 
 /* Botón de Productos Destacados */
 .featured-products .btn.btn--primary {
-  width: auto;           
-  padding: 10px 20px;    
-  font-size: 0.95rem;    
+  width: auto;
+  padding: 10px 20px;
+  font-size: 0.95rem;
   border-radius: 6px;
   margin-top: 20px;
 }
@@ -1432,4 +1438,508 @@ body {
 .site-header__action:focus-visible .material-symbols-outlined,
 .site-header__action-btn:focus-visible .material-symbols-outlined {
   color: #004aad; /* tu azul principal */
+}
+
+/* =======================
+   Carrito de compras
+======================= */
+
+#link-carrito {
+  position: relative;
+}
+
+.cart-badge {
+  position: absolute;
+  top: -6px;
+  right: -10px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: #e4e7ec;
+  color: #1b1b1b;
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body.cart-open {
+  overflow: hidden;
+}
+
+.cart-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 6000;
+  display: none;
+}
+
+.cart-modal.is-open {
+  display: block;
+}
+
+.cart-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(22, 28, 45, 0.3);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.cart-modal.is-open .cart-modal__overlay {
+  opacity: 1;
+}
+
+.cart-modal__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(420px, 100%);
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -6px 0 24px rgba(15, 23, 42, 0.15);
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+}
+
+.cart-modal.is-open .cart-modal__panel {
+  transform: translateX(0);
+}
+
+.cart-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px clamp(20px, 4vw, 28px);
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.cart-modal__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #1b1b1b;
+}
+
+.cart-modal__close {
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #4b5563;
+}
+
+.cart-modal__close:hover,
+.cart-modal__close:focus-visible {
+  color: #1b1b1b;
+}
+
+.cart-modal__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: clamp(20px, 4vw, 28px);
+  overflow: hidden;
+}
+
+.cart-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+  color: #4b5563;
+}
+
+.cart-empty__icon {
+  font-size: 3rem;
+}
+
+.cart-empty h3 {
+  font-size: 1.3rem;
+  margin: 0;
+  color: #111827;
+}
+
+.cart-empty p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.cart-empty__cta {
+  width: auto;
+  padding: 12px 24px;
+  border-radius: 999px;
+}
+
+.cart-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: 100%;
+}
+
+.cart-items {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-right: 6px;
+}
+
+.cart-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  background: #f9fafb;
+}
+
+.cart-item__details {
+  display: flex;
+  flex-direction: column;
+}
+
+.cart-item__remove {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #6b7280;
+}
+
+.cart-item__remove:hover,
+.cart-item__remove:focus-visible {
+  color: #111827;
+}
+
+.cart-item__media img {
+  width: 100%;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.cart-item__title {
+  font-size: 1rem;
+  margin: 0 0 4px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.cart-item__subtitle {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.cart-item__prices {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.cart-item__original {
+  color: #9ca3af;
+  text-decoration: line-through;
+  font-size: 0.85rem;
+}
+
+.cart-item__price {
+  font-weight: 700;
+  color: #004aad;
+}
+
+.cart-item__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.cart-item__quantity {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.cart-item__quantity button {
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: #f3f4f6;
+  cursor: pointer;
+  font-size: 1.2rem;
+  display: grid;
+  place-items: center;
+}
+
+.cart-item__quantity span {
+  min-width: 42px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.cart-item__total {
+  font-weight: 700;
+  color: #111827;
+}
+
+.shipping-section h3,
+.summary-section h3 {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.shipping-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shipping-form__group {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: #f3f4f6;
+  padding: 4px;
+  border-radius: 999px;
+}
+
+.shipping-form__group input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 10px 16px;
+  font-size: 0.95rem;
+  border-radius: 999px;
+}
+
+.shipping-form__group input:focus {
+  outline: none;
+}
+
+.shipping-form__group button {
+  border: none;
+  background: #004aad;
+  color: #fff;
+  font-weight: 600;
+  padding: 10px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+}
+
+.shipping-form__group button:hover {
+  background: #003080;
+}
+
+.shipping-result {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.shipping-result--error {
+  color: #b91c1c;
+}
+
+.summary-section {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.summary-row--total {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.summary-note {
+  margin: -8px 0 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.summary-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-btn {
+  width: 100%;
+  padding: 14px 18px;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summary-btn--primary {
+  background: #e53935;
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(229, 57, 53, 0.25);
+}
+
+.summary-btn--primary:hover {
+  transform: translateY(-1px);
+}
+
+.summary-btn--secondary {
+  background: transparent;
+  color: #e53935;
+  border: 1px solid #e53935;
+}
+
+.summary-btn--secondary:hover {
+  background: rgba(229, 57, 53, 0.08);
+}
+
+.cart-toast-container {
+  position: fixed;
+  top: clamp(70px, 12vh, 120px);
+  right: clamp(16px, 4vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 6500;
+  pointer-events: none;
+}
+
+.cart-toast {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 14px;
+  padding: 14px 18px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  min-width: 220px;
+  transform: translateY(-10px);
+  opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.cart-toast.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.cart-toast__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.cart-toast__price {
+  font-weight: 600;
+  color: #004aad;
+}
+
+@media (max-width: 1024px) {
+  .cart-modal__panel {
+    width: min(480px, 90%);
+  }
+
+  .cart-item {
+    grid-template-columns: 80px 1fr;
+  }
+
+  .cart-item__media img {
+    height: 80px;
+  }
+}
+
+@media (max-width: 768px) {
+  .cart-modal__panel {
+    width: 100%;
+    max-width: none;
+  }
+
+  .cart-modal__body {
+    padding: 20px;
+  }
+
+  .cart-item {
+    grid-template-columns: 72px 1fr;
+    padding: 14px;
+  }
+
+  .cart-item__controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cart-item__total {
+    align-self: flex-end;
+  }
+
+  .shipping-form__group {
+    flex-direction: column;
+    align-items: stretch;
+    background: transparent;
+    padding: 0;
+  }
+
+  .shipping-form__group input,
+  .shipping-form__group button {
+    border-radius: 12px;
+  }
+
+  .shipping-form__group button {
+    width: 100%;
+  }
+
+  .summary-btn {
+    border-radius: 12px;
+  }
+
+  .cart-toast-container {
+    left: 16px;
+    right: 16px;
+    top: auto;
+    bottom: clamp(20px, 8vh, 40px);
+  }
+
+  .cart-toast {
+    min-width: auto;
+  }
 }

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -76,9 +76,10 @@
 </div>
 
 
-      <a href="#" class="site-header__action" id="link-carrito">
+      <a href="#" class="site-header__action" id="link-carrito" aria-label="Abrir carrito">
   <span class="site-header__action-icon">
     <span class="material-symbols-outlined">shopping_cart</span>
+    <span class="cart-badge" aria-hidden="true">0</span>
   </span>
   <span class="site-header__action-label"></span>
 </a>
@@ -394,6 +395,61 @@
     </form>
   </div>
 </div>
+
+
+<!-- Carrito de compras -->
+<div class="cart-modal" id="cart-modal" aria-hidden="true">
+  <div class="cart-modal__overlay" data-cart-close></div>
+  <aside class="cart-modal__panel" role="dialog" aria-labelledby="cart-modal-title" aria-modal="true" tabindex="-1">
+    <header class="cart-modal__header">
+      <h2 id="cart-modal-title">Tu carrito</h2>
+      <button class="cart-modal__close" type="button" aria-label="Cerrar carrito" data-cart-close>&times;</button>
+    </header>
+
+    <div class="cart-modal__body">
+      <div class="cart-empty" data-cart-empty>
+        <div class="cart-empty__icon" aria-hidden="true">🛒</div>
+        <h3>Tu carrito está vacío</h3>
+        <p>Agrega algunos productos para comenzar tu compra</p>
+        <button class="btn btn--primary cart-empty__cta" type="button" data-cart-close>Seguir Comprando</button>
+      </div>
+
+      <div class="cart-content" data-cart-content hidden>
+        <div class="cart-items" data-cart-items role="list"></div>
+
+        <section class="shipping-section" data-shipping-section>
+          <h3>Medios de envío</h3>
+          <form class="shipping-form" data-shipping-form>
+            <label for="shipping-postal-code" class="visually-hidden">Código postal</label>
+            <div class="shipping-form__group">
+              <input type="text" id="shipping-postal-code" name="postalCode" placeholder="Tu código postal" autocomplete="postal-code" inputmode="numeric">
+              <button type="submit">CALCULAR</button>
+            </div>
+            <p class="shipping-result" data-shipping-result>Calculá tu envío para conocer el costo.</p>
+          </form>
+        </section>
+
+        <section class="summary-section" data-summary-section>
+          <div class="summary-row">
+            <span data-summary-count>0 productos</span>
+            <span data-summary-subtotal>$0</span>
+          </div>
+          <div class="summary-row summary-row--total">
+            <span>Total con envío</span>
+            <span data-summary-total>$0</span>
+          </div>
+          <p class="summary-note" data-summary-note>Calculá el envío para ver el total final.</p>
+          <div class="summary-actions">
+            <button type="button" class="summary-btn summary-btn--primary">Iniciar compra</button>
+            <button type="button" class="summary-btn summary-btn--secondary" data-cart-close>Ver más productos</button>
+          </div>
+        </section>
+      </div>
+    </div>
+  </aside>
+</div>
+
+<div class="cart-toast-container" aria-live="polite" aria-atomic="true"></div>
 
 
 

--- a/Frontend/javaScript/main.js
+++ b/Frontend/javaScript/main.js
@@ -365,4 +365,459 @@ if (header && navBottom) {
   }
 }
 
+  /* ===========================
+     🔹 Datos de productos demo
+  =========================== */
+  const currencyFormatter = new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    maximumFractionDigits: 0
+  });
+
+  const formatCurrency = (value) => currencyFormatter.format(value);
+
+  const demoProducts = [
+    {
+      id: "vesper-aurora",
+      name: "Aurora Nocturna",
+      subtitle: "Fragancia femenina",
+      price: 38500,
+      originalPrice: 42900,
+      image: "img/categoria_perfumes_1.avif"
+    },
+    {
+      id: "vesper-orion",
+      name: "Orion Intense",
+      subtitle: "Perfume masculino",
+      price: 41200,
+      originalPrice: 45200,
+      image: "img/categoria_perfumes_2.avif"
+    },
+    {
+      id: "vesper-summit",
+      name: "Summit Vapor",
+      subtitle: "Vape sabor frutos rojos",
+      price: 21500,
+      originalPrice: 0,
+      image: "img/categoria_vapes_1.avif"
+    },
+    {
+      id: "vesper-lumen",
+      name: "Lumen Deluxe",
+      subtitle: "Decant 15ml",
+      price: 13200,
+      originalPrice: 14900,
+      image: "img/categoria_perfumes_1.avif"
+    },
+    {
+      id: "vesper-zenith",
+      name: "Zenith Oud",
+      subtitle: "Fragancia unisex",
+      price: 47800,
+      originalPrice: 51200,
+      image: "img/categoria_perfumes_2.avif"
+    },
+    {
+      id: "vesper-wave",
+      name: "Wave Citrus",
+      subtitle: "Vape edición limitada",
+      price: 22800,
+      originalPrice: 0,
+      image: "img/categoria_vapes_1.avif"
+    }
+  ];
+
+  const productListContainer = document.getElementById("product-list");
+  const productsGrid = document.getElementById("productos-lista");
+
+  const createProductCard = (product) => {
+    const card = document.createElement("article");
+    card.className = "product";
+
+    const originalPrice = product.originalPrice && product.originalPrice > product.price
+      ? `<p class="discount">${formatCurrency(product.originalPrice)}</p>`
+      : "";
+
+    card.innerHTML = `
+      <img src="${product.image}" alt="${product.name}">
+      <h3>${product.name}</h3>
+      <p class="product-subtitle">${product.subtitle}</p>
+      ${originalPrice}
+      <p class="price">${formatCurrency(product.price)}</p>
+      <button type="button" class="btn btn--primary product__add" data-add-to-cart
+        data-product-id="${product.id}"
+        data-product-name="${product.name}"
+        data-product-subtitle="${product.subtitle}"
+        data-product-price="${product.price}"
+        data-product-original-price="${product.originalPrice ?? 0}"
+        data-product-image="${product.image}">
+        Agregar al carrito
+      </button>
+    `;
+
+    return card;
+  };
+
+  if (productListContainer && productListContainer.children.length === 0) {
+    demoProducts.slice(0, 4).forEach((product) => {
+      productListContainer.appendChild(createProductCard(product));
+    });
+  }
+
+  if (productsGrid && productsGrid.children.length === 0) {
+    demoProducts.forEach((product) => {
+      productsGrid.appendChild(createProductCard(product));
+    });
+  }
+
+  /* ===========================
+     🔹 Carrito de compras
+  =========================== */
+  const cartModal = document.getElementById("cart-modal");
+  const cartTrigger = document.getElementById("link-carrito");
+  const cartBadge = cartTrigger?.querySelector(".cart-badge");
+  const cartItemsContainer = cartModal?.querySelector("[data-cart-items]");
+  const cartContent = cartModal?.querySelector("[data-cart-content]");
+  const emptyState = cartModal?.querySelector("[data-cart-empty]");
+  const shippingSection = cartModal?.querySelector("[data-shipping-section]");
+  const summarySection = cartModal?.querySelector("[data-summary-section]");
+  const shippingForm = cartModal?.querySelector("[data-shipping-form]");
+  const shippingResult = cartModal?.querySelector("[data-shipping-result]");
+  const summaryCount = cartModal?.querySelector("[data-summary-count]");
+  const summarySubtotal = cartModal?.querySelector("[data-summary-subtotal]");
+  const summaryTotal = cartModal?.querySelector("[data-summary-total]");
+  const summaryNote = cartModal?.querySelector("[data-summary-note]");
+  const toastContainer = document.querySelector(".cart-toast-container");
+
+  const cartState = {
+    items: [],
+    shippingCost: null,
+    shippingPostalCode: null
+  };
+
+  let lastFocusedElement = null;
+
+  const getCartQuantity = () => cartState.items.reduce((acc, item) => acc + item.quantity, 0);
+
+  const updateCartBadge = () => {
+    const totalQuantity = getCartQuantity();
+    if (cartBadge) {
+      cartBadge.textContent = String(totalQuantity);
+    }
+    if (cartTrigger) {
+      if (totalQuantity > 0) {
+        cartTrigger.setAttribute(
+          "aria-label",
+          `Abrir carrito (${totalQuantity} producto${totalQuantity === 1 ? "" : "s"})`
+        );
+      } else {
+        cartTrigger.setAttribute("aria-label", "Abrir carrito");
+      }
+    }
+  };
+
+  const renderCartItems = () => {
+    if (!cartItemsContainer) return;
+    cartItemsContainer.innerHTML = "";
+
+    cartState.items.forEach((item) => {
+      const element = document.createElement("article");
+      element.className = "cart-item";
+      element.dataset.id = item.id;
+
+      const originalPrice = item.originalPrice && item.originalPrice > item.price
+        ? `<span class="cart-item__original">${formatCurrency(item.originalPrice)}</span>`
+        : "";
+
+      element.innerHTML = `
+        <button class="cart-item__remove" type="button" data-action="remove" aria-label="Eliminar ${item.name}">🗑️</button>
+        <div class="cart-item__media">
+          <img src="${item.image}" alt="${item.name}">
+        </div>
+        <div class="cart-item__details">
+          <h4 class="cart-item__title">${item.name}</h4>
+          <p class="cart-item__subtitle">${item.subtitle ?? ""}</p>
+          <div class="cart-item__prices">
+            ${originalPrice}
+            <span class="cart-item__price">${formatCurrency(item.price)}</span>
+          </div>
+          <div class="cart-item__controls">
+            <div class="cart-item__quantity">
+              <button type="button" data-action="decrease" aria-label="Restar uno">−</button>
+              <span>${item.quantity}</span>
+              <button type="button" data-action="increase" aria-label="Sumar uno">+</button>
+            </div>
+            <span class="cart-item__total">${formatCurrency(item.quantity * item.price)}</span>
+          </div>
+        </div>
+      `;
+
+      cartItemsContainer.appendChild(element);
+    });
+  };
+
+  const resetShippingState = () => {
+    cartState.shippingCost = null;
+    cartState.shippingPostalCode = null;
+    if (shippingForm) {
+      shippingForm.reset();
+    }
+    if (shippingResult) {
+      shippingResult.textContent = "Calculá tu envío para conocer el costo.";
+      shippingResult.classList.remove("shipping-result--error");
+    }
+  };
+
+  const updateSummary = () => {
+    if (!summaryCount || !summarySubtotal || !summaryTotal) return;
+    const totalQuantity = getCartQuantity();
+    const subtotal = cartState.items.reduce((acc, item) => acc + item.price * item.quantity, 0);
+
+    summaryCount.textContent = `${totalQuantity} producto${totalQuantity === 1 ? "" : "s"}`;
+    summarySubtotal.textContent = formatCurrency(subtotal);
+
+    let total = subtotal;
+
+    if (cartState.shippingCost != null) {
+      total += cartState.shippingCost;
+      if (summaryNote) {
+        if (cartState.shippingCost === 0) {
+          summaryNote.textContent = cartState.shippingPostalCode
+            ? `Envío gratis para ${cartState.shippingPostalCode.toUpperCase()}.`
+            : "Envío gratis.";
+        } else {
+          summaryNote.textContent = cartState.shippingPostalCode
+            ? `Incluye envío estimado a ${cartState.shippingPostalCode.toUpperCase()}.`
+            : "Incluye envío estimado.";
+        }
+      }
+    } else if (summaryNote) {
+      summaryNote.textContent = "Calculá el envío para ver el total final.";
+    }
+
+    summaryTotal.textContent = formatCurrency(total);
+  };
+
+  const updateCartUI = () => {
+    const hasItems = cartState.items.length > 0;
+
+    if (emptyState) {
+      emptyState.hidden = hasItems;
+    }
+    if (cartContent) {
+      cartContent.hidden = !hasItems;
+    }
+    if (shippingSection) {
+      shippingSection.hidden = !hasItems;
+    }
+    if (summarySection) {
+      summarySection.hidden = !hasItems;
+    }
+
+    if (hasItems) {
+      renderCartItems();
+      updateSummary();
+    } else {
+      if (cartItemsContainer) {
+        cartItemsContainer.innerHTML = "";
+      }
+      resetShippingState();
+    }
+  };
+
+  const openCart = () => {
+    if (!cartModal) return;
+    updateCartUI();
+    cartModal.classList.add("is-open");
+    cartModal.setAttribute("aria-hidden", "false");
+    document.body.classList.add("cart-open");
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const panel = cartModal.querySelector(".cart-modal__panel");
+    if (panel instanceof HTMLElement) {
+      panel.focus();
+    }
+    if (cartTrigger) {
+      cartTrigger.setAttribute("aria-expanded", "true");
+    }
+  };
+
+  const closeCart = () => {
+    if (!cartModal) return;
+    cartModal.classList.remove("is-open");
+    cartModal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("cart-open");
+    if (cartTrigger) {
+      cartTrigger.setAttribute("aria-expanded", "false");
+    }
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  };
+
+  const showCartToast = (item) => {
+    if (!toastContainer) return;
+    const toast = document.createElement("div");
+    toast.className = "cart-toast";
+
+    const title = document.createElement("p");
+    title.className = "cart-toast__title";
+    title.textContent = `Agregaste ${item.name}`;
+
+    const price = document.createElement("span");
+    price.className = "cart-toast__price";
+    price.textContent = formatCurrency(item.price);
+
+    toast.appendChild(title);
+    toast.appendChild(price);
+
+    if (toastContainer.childElementCount >= 3) {
+      toastContainer.removeChild(toastContainer.firstElementChild);
+    }
+
+    toastContainer.appendChild(toast);
+
+    requestAnimationFrame(() => {
+      toast.classList.add("is-visible");
+    });
+
+    setTimeout(() => {
+      toast.classList.remove("is-visible");
+      setTimeout(() => {
+        toast.remove();
+      }, 250);
+    }, 3200);
+  };
+
+  const estimateShipping = (postalCode) => {
+    const cleaned = postalCode.replace(/\s+/g, "");
+    if (cleaned.length < 4) {
+      return null;
+    }
+
+    let cost = 2400;
+    const prefix = cleaned[0];
+
+    if (prefix === "1") {
+      cost = 0;
+    } else if (prefix === "2" || prefix === "3") {
+      cost = 1800;
+    } else if (prefix === "4" || prefix === "5") {
+      cost = 2100;
+    }
+
+    const message = cost === 0
+      ? `Envío gratis para ${cleaned.toUpperCase()}.`
+      : `Envío estimado a ${cleaned.toUpperCase()}: ${formatCurrency(cost)}.`;
+
+    return { cost, message };
+  };
+
+  const addProductToCart = (product) => {
+    const existing = cartState.items.find((item) => item.id === product.id);
+    if (existing) {
+      existing.quantity += 1;
+    } else {
+      cartState.items.push({
+        ...product,
+        quantity: 1
+      });
+    }
+    updateCartBadge();
+    updateCartUI();
+    showCartToast(product);
+  };
+
+  cartTrigger?.addEventListener("click", (event) => {
+    event.preventDefault();
+    openCart();
+  });
+
+  cartModal?.addEventListener("click", (event) => {
+    const closeTarget = event.target instanceof HTMLElement ? event.target.closest("[data-cart-close]") : null;
+    if (closeTarget) {
+      event.preventDefault();
+      closeCart();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && cartModal?.classList.contains("is-open")) {
+      closeCart();
+    }
+  });
+
+  cartItemsContainer?.addEventListener("click", (event) => {
+    const button = event.target instanceof HTMLElement ? event.target.closest("button[data-action]") : null;
+    if (!button) return;
+    const action = button.dataset.action;
+    const itemElement = button.closest(".cart-item");
+    if (!itemElement) return;
+    const { id } = itemElement.dataset;
+    if (!id) return;
+
+    const item = cartState.items.find((entry) => entry.id === id);
+    if (!item) return;
+
+    if (action === "increase") {
+      item.quantity += 1;
+    } else if (action === "decrease") {
+      if (item.quantity > 1) {
+        item.quantity -= 1;
+      } else {
+        cartState.items = cartState.items.filter((entry) => entry.id !== id);
+      }
+    } else if (action === "remove") {
+      cartState.items = cartState.items.filter((entry) => entry.id !== id);
+    }
+
+    updateCartBadge();
+    updateCartUI();
+  });
+
+  shippingForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!shippingResult) return;
+
+    const input = shippingForm.querySelector("input[name='postalCode']");
+    const postalCode = input?.value.trim() ?? "";
+
+    const estimation = estimateShipping(postalCode);
+    if (!estimation) {
+      shippingResult.textContent = "Ingresá un código postal válido.";
+      shippingResult.classList.add("shipping-result--error");
+      cartState.shippingCost = null;
+      cartState.shippingPostalCode = null;
+      updateSummary();
+      return;
+    }
+
+    shippingResult.textContent = estimation.message;
+    shippingResult.classList.remove("shipping-result--error");
+    cartState.shippingCost = estimation.cost;
+    cartState.shippingPostalCode = postalCode;
+    updateSummary();
+  });
+
+  document.addEventListener("click", (event) => {
+    const trigger = event.target instanceof HTMLElement ? event.target.closest("[data-add-to-cart]") : null;
+    if (!trigger) return;
+    event.preventDefault();
+
+    const { productId, productName, productSubtitle, productPrice, productOriginalPrice, productImage } = trigger.dataset;
+    if (!productId || !productName || !productPrice) return;
+
+    const product = {
+      id: productId,
+      name: productName,
+      subtitle: productSubtitle ?? "",
+      price: Number(productPrice),
+      originalPrice: Number(productOriginalPrice ?? 0),
+      image: productImage ?? "img/categoria_perfumes_1.avif"
+    };
+
+    addProductToCart(product);
+  });
+
+  updateCartBadge();
+
 });

--- a/Frontend/productos.html
+++ b/Frontend/productos.html
@@ -144,9 +144,10 @@
 
 
 
-      <a href="#" class="site-header__action" id="link-carrito">
+      <a href="#" class="site-header__action" id="link-carrito" aria-label="Abrir carrito">
   <span class="site-header__action-icon">
     <span class="material-symbols-outlined">shopping_cart</span>
+    <span class="cart-badge" aria-hidden="true">0</span>
   </span>
   <span class="site-header__action-label"></span>
 </a>
@@ -315,6 +316,60 @@
       </div>
     </div>
   </footer>
+
+  <!-- Carrito de compras -->
+  <div class="cart-modal" id="cart-modal" aria-hidden="true">
+    <div class="cart-modal__overlay" data-cart-close></div>
+    <aside class="cart-modal__panel" role="dialog" aria-labelledby="cart-modal-title" aria-modal="true" tabindex="-1">
+      <header class="cart-modal__header">
+        <h2 id="cart-modal-title">Tu carrito</h2>
+        <button class="cart-modal__close" type="button" aria-label="Cerrar carrito" data-cart-close>&times;</button>
+      </header>
+
+      <div class="cart-modal__body">
+        <div class="cart-empty" data-cart-empty>
+          <div class="cart-empty__icon" aria-hidden="true">🛒</div>
+          <h3>Tu carrito está vacío</h3>
+          <p>Agrega algunos productos para comenzar tu compra</p>
+          <button class="btn btn--primary cart-empty__cta" type="button" data-cart-close>Seguir Comprando</button>
+        </div>
+
+        <div class="cart-content" data-cart-content hidden>
+          <div class="cart-items" data-cart-items role="list"></div>
+
+          <section class="shipping-section" data-shipping-section>
+            <h3>Medios de envío</h3>
+            <form class="shipping-form" data-shipping-form>
+              <label for="shipping-postal-code" class="visually-hidden">Código postal</label>
+              <div class="shipping-form__group">
+                <input type="text" id="shipping-postal-code" name="postalCode" placeholder="Tu código postal" autocomplete="postal-code" inputmode="numeric">
+                <button type="submit">CALCULAR</button>
+              </div>
+              <p class="shipping-result" data-shipping-result>Calculá tu envío para conocer el costo.</p>
+            </form>
+          </section>
+
+          <section class="summary-section" data-summary-section>
+            <div class="summary-row">
+              <span data-summary-count>0 productos</span>
+              <span data-summary-subtotal>$0</span>
+            </div>
+            <div class="summary-row summary-row--total">
+              <span>Total con envío</span>
+              <span data-summary-total>$0</span>
+            </div>
+            <p class="summary-note" data-summary-note>Calculá el envío para ver el total final.</p>
+            <div class="summary-actions">
+              <button type="button" class="summary-btn summary-btn--primary">Iniciar compra</button>
+              <button type="button" class="summary-btn summary-btn--secondary" data-cart-close>Ver más productos</button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </aside>
+  </div>
+
+  <div class="cart-toast-container" aria-live="polite" aria-atomic="true"></div>
 
   <!-- Scripts -->
   <script src="../Frontend/javaScript/main.js"></script>


### PR DESCRIPTION
## Summary
- add a responsive cart modal overlay with summary, shipping calculator, and close controls on both main pages
- hook up dynamic cart management with badge updates and toast notifications, including shipping estimation
- populate demo products with add-to-cart buttons to exercise the new cart workflow

## Testing
- [x] Manual smoke test (`python3 -m http.server 8000`)


------
https://chatgpt.com/codex/tasks/task_e_68df1360f8b4832e99f0d045d460317c