### PR TITLE
Improve mobile header responsiveness

### DIFF
--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -433,12 +433,12 @@ body {
   .site-header__top {
     align-items: center;
     justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 0 16px;
+    flex-wrap: nowrap;
+    gap: 12px;
   }
 
   .menu-toggle {
-    order: 1;
+    order: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -451,12 +451,38 @@ body {
   }
 
   .site-header__logo {
-    order: 2;
+    order: 1;
     margin: 0;
+    flex: 0 0 auto;
   }
 
   .site-header__logo img {
-    max-height: 30px;
+    max-height: 32px;
+    max-width: 110px;
+    height: auto;
+    width: auto;
+  }
+
+  .site-header__search {
+    order: 2;
+    flex: 1 1 auto;
+    min-width: 0;
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 999px;
+    transform: none;
+    overflow: hidden;
+    max-height: none;
+    opacity: 1;
+    visibility: visible;
   }
 
   .site-header__actions {
@@ -464,8 +490,9 @@ body {
     margin-left: auto;
     display: flex;
     align-items: center;
-    flex-direction: row-reverse;
-    gap: 16px;
+    flex-direction: row;
+    gap: 12px;
+    flex: 0 0 auto;
   }
 
   .search-toggle {
@@ -494,58 +521,23 @@ body {
     font-size: 1.2rem;
   }
 
-  .site-header__search {
-    order: 4;
-    flex-basis: 100%;
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    max-width: none;
-    margin: 0;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: 999px;
-    transform: none;
-    overflow: hidden;
-    max-height: 0;
-    opacity: 0;
-    visibility: hidden;
-    transition: max-height 0.35s ease, opacity 0.25s ease, margin 0.25s ease, padding 0.25s ease, border 0.25s ease;
-  }
-
-  .site-header.is-search-open .site-header__search {
-    margin-top: 12px;
-    padding: 4px 12px;
-    border: 1px solid #cdcdcd;
-    background: #ffffff;
-    max-height: 72px;
-    opacity: 1;
-    visibility: visible;
-  }
-
   .site-header__search input {
-    flex: 1 1 clamp(140px, 70vw, 520px);
+    flex: 1 1 clamp(140px, 45vw, 100%);
     min-width: 0;
-    width: auto;
-    height: 40px;
+    width: 100%;
+    height: 38px;
     padding: 0 12px;
-    border: none;
+    border: 1px solid #cdcdcd;
     border-radius: 999px;
-    background: transparent;
-    font-size: 0.95rem;
-  }
-
-  .site-header.is-search-open .site-header__search input {
     background: #ffffff;
+    font-size: 0.9rem;
   }
 
   .site-header__search button {
     position: static;
     transform: none;
     margin-left: 0;
+    flex: 0 0 auto;
     background: none;
     border: none;
     color: #868686;
@@ -554,6 +546,10 @@ body {
   .site-header__search button:hover,
   .site-header__search button:focus-visible {
     color: #004aad;
+  }
+
+  .search-toggle {
+    display: none;
   }
 
   .main-nav {


### PR DESCRIPTION
## Summary
- keep the header layout flex-aligned on small screens while preventing element overlap
- resize the logo and search input to fit within the available mobile space
- hide the redundant mobile search toggle so the account and cart icons stay aligned on the right

## Testing
- Manual inspection in a 375px-wide viewport

------
https://chatgpt.com/codex/tasks/task_e_68e2d5cf15e0832eb464c5d89cb7e11e