### PR TITLE
Improve mobile benefits carousel

### DIFF
--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -1660,6 +1660,8 @@ body.is-cart-open {
 
   .benefits .container {
     flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: stretch;
     overflow-x: auto;
     gap: 16px;
     padding: 0 16px;

--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -735,6 +735,10 @@ body {
   width: 1px;
   background: rgba(0, 0, 0, 0.2);
 }
+
+.benefits__scroll-indicator {
+  display: none;
+}
 /* =======================
    Categorías
 ======================= */
@@ -1649,8 +1653,78 @@ body.is-cart-open {
 }
 
 @media (max-width: 768px) {
+  .benefits {
+    position: relative;
+    padding: 32px 0;
+  }
+
+  .benefits .container {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 16px;
+    padding: 0 16px;
+    margin: 0;
+    scroll-snap-type: x mandatory;
+    scroll-padding: 0 16px;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .benefits .container::-webkit-scrollbar {
+    display: none;
+  }
+
+  .benefit {
+    flex: 0 0 85%;
+    max-width: 85%;
+    background: #ffffff;
+    border-radius: 18px;
+    padding: 24px 20px;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  }
+
+  .benefit h3 {
+    font-size: 1.05rem;
+  }
+
+  .benefit p {
+    font-size: 0.95rem;
+  }
+
   .benefit:not(:last-child)::after {
     display: none; /* elimina separador en mobile */
+  }
+
+  .benefits__scroll-indicator {
+    position: absolute;
+    right: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(0, 74, 173, 0.85), rgba(0, 74, 173, 0.65));
+    color: #ffffff;
+    box-shadow: 0 10px 24px rgba(0, 74, 173, 0.35);
+    pointer-events: none;
+    z-index: 5;
+    opacity: 1;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .benefits__scroll-indicator span {
+    font-size: 1.75rem;
+    line-height: 1;
+  }
+
+  .benefits__scroll-indicator.is-hidden {
+    opacity: 0;
+    transform: translateY(-50%) scale(0.9);
   }
 }
 

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -246,6 +246,9 @@
           <p>En efectivo y transferencia bancaria</p>
         </article>
       </div>
+      <div class="benefits__scroll-indicator" aria-hidden="true">
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
+      </div>
     </section>
 
     <!-- Categorías -->

--- a/Frontend/javaScript/main.js
+++ b/Frontend/javaScript/main.js
@@ -33,6 +33,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const modalLogin = document.getElementById("modal-login");
   const modalRegister = document.getElementById("modal-register");
 
+  document.body.classList.remove("is-cart-open");
+
+  [modalLogin, modalRegister].forEach((modal) => {
+    if (modal) {
+      modal.classList.remove("active");
+      modal.setAttribute("aria-hidden", "true");
+    }
+  });
+
   const btnLogin = document.getElementById("btn-login");
   const btnRegister = document.getElementById("btn-register");
 
@@ -444,6 +453,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const cartTrigger = document.getElementById("link-carrito");
   const cartCountBadge = document.getElementById("cart-count");
   const toastLayer = document.querySelector(".cart-toast-layer");
+
+  if (cartModal) {
+    cartModal.classList.remove("is-open");
+    cartModal.setAttribute("aria-hidden", "true");
+  }
 
   const cartState = {
     items: [],
@@ -1042,6 +1056,12 @@ document.addEventListener("DOMContentLoaded", () => {
   if (benefitsTrack && benefitsIndicator) {
     const mobileBenefitsQuery = window.matchMedia("(max-width: 768px)");
 
+    const ensureStartPosition = () => {
+      if (mobileBenefitsQuery.matches) {
+        benefitsTrack.scrollLeft = 0;
+      }
+    };
+
     const toggleIndicator = () => {
       if (!mobileBenefitsQuery.matches) {
         benefitsIndicator.classList.add("is-hidden");
@@ -1072,13 +1092,26 @@ document.addEventListener("DOMContentLoaded", () => {
     benefitsTrack.addEventListener("scroll", handleScroll, { passive: true });
     window.addEventListener("resize", handleResize);
 
+    const handleMediaChange = (event) => {
+      const matches = typeof event.matches === "boolean" ? event.matches : mobileBenefitsQuery.matches;
+      if (matches) {
+        ensureStartPosition();
+      }
+      toggleIndicator();
+    };
+
     if (typeof mobileBenefitsQuery.addEventListener === "function") {
-      mobileBenefitsQuery.addEventListener("change", toggleIndicator);
+      mobileBenefitsQuery.addEventListener("change", handleMediaChange);
     } else if (typeof mobileBenefitsQuery.addListener === "function") {
-      mobileBenefitsQuery.addListener(toggleIndicator);
+      mobileBenefitsQuery.addListener(handleMediaChange);
     }
 
-    window.addEventListener("load", toggleIndicator);
+    window.addEventListener("load", () => {
+      ensureStartPosition();
+      toggleIndicator();
+    });
+
+    ensureStartPosition();
     toggleIndicator();
   }
 

--- a/Frontend/javaScript/main.js
+++ b/Frontend/javaScript/main.js
@@ -1032,6 +1032,56 @@ document.addEventListener("DOMContentLoaded", () => {
   filtersMediaQuery.addEventListener("change", handleFiltersMediaChange);
   handleFiltersMediaChange(filtersMediaQuery);
 
+  /* ===========================
+     🔹 Carrusel de beneficios (mobile)
+  =========================== */
+  const benefitsSection = document.querySelector(".benefits");
+  const benefitsTrack = benefitsSection?.querySelector(".container");
+  const benefitsIndicator = benefitsSection?.querySelector(".benefits__scroll-indicator");
+
+  if (benefitsTrack && benefitsIndicator) {
+    const mobileBenefitsQuery = window.matchMedia("(max-width: 768px)");
+
+    const toggleIndicator = () => {
+      if (!mobileBenefitsQuery.matches) {
+        benefitsIndicator.classList.add("is-hidden");
+        return;
+      }
+
+      const { scrollLeft, scrollWidth, clientWidth } = benefitsTrack;
+      const maxScroll = scrollWidth - clientWidth;
+      const canScroll = maxScroll > 2;
+
+      if (!canScroll) {
+        benefitsIndicator.classList.add("is-hidden");
+        return;
+      }
+
+      const isAtEnd = scrollLeft >= maxScroll - 2;
+      benefitsIndicator.classList.toggle("is-hidden", isAtEnd);
+    };
+
+    const handleScroll = () => {
+      window.requestAnimationFrame(toggleIndicator);
+    };
+
+    const handleResize = () => {
+      window.requestAnimationFrame(toggleIndicator);
+    };
+
+    benefitsTrack.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    if (typeof mobileBenefitsQuery.addEventListener === "function") {
+      mobileBenefitsQuery.addEventListener("change", toggleIndicator);
+    } else if (typeof mobileBenefitsQuery.addListener === "function") {
+      mobileBenefitsQuery.addListener(toggleIndicator);
+    }
+
+    window.addEventListener("load", toggleIndicator);
+    toggleIndicator();
+  }
+
 /* ===========================
    🔹 Sombra dinámica del header
 =========================== */


### PR DESCRIPTION
## Summary
- restructure the benefits section markup to include a scroll indicator for the mobile carousel
- restyle the benefits cards under 768px to show a horizontal scrollable layout with snap points and card styling
- add JavaScript that hides the arrow indicator when the carousel is fully scrolled or not in mobile view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53179fc38832e8b0dede57a3a4437