### PR TITLE
Adjust mobile benefits section to horizontal carousel

### DIFF
--- a/Frontend/css/style.css
+++ b/Frontend/css/style.css
@@ -735,6 +735,83 @@ body {
   width: 1px;
   background: rgba(0, 0, 0, 0.2);
 }
+
+.benefits__scroll-indicator {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .benefits {
+    position: relative;
+    padding: 28px 0;
+    margin-top: 0;
+  }
+
+  .benefits .container {
+    gap: 16px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-padding-left: clamp(16px, 5vw, 32px);
+    padding-bottom: 8px;
+  }
+
+  .benefits .container::-webkit-scrollbar {
+    display: none;
+  }
+
+  .benefit {
+    flex: 0 0 85%;
+    max-width: 85%;
+    scroll-snap-align: start;
+    background: #f7f7f7;
+    padding: 20px;
+    border-radius: 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  }
+
+  .benefit:not(:last-child)::after {
+    display: none;
+  }
+
+  .benefits__scroll-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 50%;
+    right: clamp(8px, 4vw, 24px);
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(0, 74, 173, 0.9), rgba(0, 74, 173, 0.65));
+    color: #ffffff;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.15);
+    border: none;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .benefits__scroll-indicator .material-symbols-outlined {
+    font-size: 1.6rem;
+  }
+
+  .benefits__scroll-indicator.is-active {
+    opacity: 0.85;
+    pointer-events: auto;
+  }
+
+  .benefits__scroll-indicator.is-active:active {
+    transform: translateY(-50%) scale(0.96);
+  }
+
+  .benefits__scroll-indicator.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
 /* =======================
    Categorías
 ======================= */

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -246,6 +246,9 @@
           <p>En efectivo y transferencia bancaria</p>
         </article>
       </div>
+      <button class="benefits__scroll-indicator" type="button" aria-hidden="true" tabindex="-1">
+        <span class="material-symbols-outlined" aria-hidden="true">arrow_forward</span>
+      </button>
     </section>
 
     <!-- Categorías -->

--- a/Frontend/javaScript/main.js
+++ b/Frontend/javaScript/main.js
@@ -335,6 +335,62 @@ document.addEventListener("DOMContentLoaded", () => {
   window.addEventListener("resize", handleResize);
   handleResize();
 
+  /* ===========================
+     🔹 Carrusel de beneficios en mobile
+  =========================== */
+  const benefitsContainer = document.querySelector(".benefits .container");
+  const benefitsIndicator = document.querySelector(".benefits__scroll-indicator");
+  const benefitsMediaQuery = window.matchMedia("(max-width: 768px)");
+
+  if (benefitsContainer && benefitsIndicator) {
+    const updateIndicatorVisibility = () => {
+      if (!benefitsMediaQuery.matches) return;
+
+      const tolerance = 4;
+      const isAtEnd = benefitsContainer.scrollLeft + benefitsContainer.clientWidth >= benefitsContainer.scrollWidth - tolerance;
+      benefitsIndicator.classList.toggle("is-hidden", isAtEnd);
+    };
+
+    const updateIndicatorState = () => {
+      if (!benefitsMediaQuery.matches) {
+        benefitsIndicator.classList.remove("is-active", "is-hidden");
+        return;
+      }
+
+      const hasOverflow = benefitsContainer.scrollWidth > benefitsContainer.clientWidth + 1;
+      benefitsIndicator.classList.toggle("is-active", hasOverflow);
+      if (!hasOverflow) {
+        benefitsIndicator.classList.remove("is-hidden");
+      } else {
+        updateIndicatorVisibility();
+      }
+    };
+
+    benefitsContainer.addEventListener("scroll", updateIndicatorVisibility, { passive: true });
+
+    benefitsIndicator.addEventListener("click", (event) => {
+      if (!benefitsMediaQuery.matches) return;
+      event.preventDefault();
+
+      const firstCard = benefitsContainer.querySelector(".benefit");
+      const cardWidth = firstCard ? firstCard.getBoundingClientRect().width : benefitsContainer.clientWidth * 0.85;
+      benefitsContainer.scrollBy({ left: cardWidth, behavior: "smooth" });
+    });
+
+    const onMediaChange = () => {
+      if (!benefitsMediaQuery.matches) {
+        benefitsContainer.scrollTo({ left: 0 });
+      }
+      updateIndicatorState();
+    };
+
+    benefitsMediaQuery.addEventListener("change", onMediaChange);
+    window.addEventListener("resize", updateIndicatorState);
+    window.addEventListener("load", updateIndicatorState);
+
+    updateIndicatorState();
+  }
+
   const currencyFormatter = new Intl.NumberFormat("es-AR", {
     style: "currency",
     currency: "ARS",


### PR DESCRIPTION
## Summary
- convert the benefits strip into a horizontally scrollable carousel for mobile viewports without affecting desktop layouts
- add a contextual scroll indicator arrow that guides users and hides when the carousel reaches the end
- refresh the mobile card styling to maintain readability and spacing immediately beneath the hero section

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e53179fc38832e8b0dede57a3a4437