### PR TITLE
Agregar administración de ventas y control de estados en panel admin

### DIFF
--- a/Backend/src/main/java/org/vesper/controller/VentaController.java
+++ b/Backend/src/main/java/org/vesper/controller/VentaController.java
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 import org.vesper.dto.VentaRequest;
 import org.vesper.dto.VentaResponse;
+import org.vesper.dto.VentaEstadoRequest;
 import org.vesper.service.VentaService;
 
 import java.util.List;
@@ -81,5 +82,19 @@ public class VentaController {
     @GetMapping("/admin/ventas/{id}")
     public ResponseEntity<VentaResponse> obtenerVentaAdmin(@PathVariable Long id) {
         return ResponseEntity.ok(ventaService.obtenerPorId(id));
+    }
+
+    /**
+     * Actualiza el estado de una venta (solo administradores).
+     *
+     * @param id      ID de la venta.
+     * @param request Datos del nuevo estado.
+     * @return Venta actualizada.
+     */
+    @PutMapping("/admin/ventas/{id}/estado")
+    public ResponseEntity<VentaResponse> actualizarEstadoVenta(
+            @PathVariable Long id,
+            @Valid @RequestBody VentaEstadoRequest request) {
+        return ResponseEntity.ok(ventaService.actualizarEstado(id, request.getEstado()));
     }
 }

--- a/Backend/src/main/java/org/vesper/dto/VentaEstadoRequest.java
+++ b/Backend/src/main/java/org/vesper/dto/VentaEstadoRequest.java
@@ -1,0 +1,17 @@
+package org.vesper.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VentaEstadoRequest {
+
+    @NotBlank(message = "El estado de la venta es obligatorio")
+    private String estado;
+}

--- a/Backend/src/main/java/org/vesper/entity/Venta.java
+++ b/Backend/src/main/java/org/vesper/entity/Venta.java
@@ -20,7 +20,7 @@ public class Venta {
      * Estados posibles de una venta.
      */
     public enum EstadoVenta {
-        PENDIENTE, COMPLETADA, CANCELADA,RECHAZADA
+        PENDIENTE, ENVIADO, RECIBIDO, COMPLETADA, CANCELADA, RECHAZADA
     }
 
     @Id

--- a/Backend/src/main/java/org/vesper/service/VentaService.java
+++ b/Backend/src/main/java/org/vesper/service/VentaService.java
@@ -18,6 +18,7 @@ import org.vesper.entity.Venta;
 import org.vesper.exception.AlreadyExistsException;
 import org.vesper.exception.ResourceNotFoundException;
 import org.vesper.exception.UnauthorizedException;
+import org.vesper.exception.VesperException;
 import org.vesper.repo.PerfumeRepository;
 import org.vesper.repo.VapeRepository;
 import org.vesper.repo.VentaRepository;
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 @Service
@@ -195,6 +197,18 @@ public class VentaService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public VentaResponse actualizarEstado(Long id, String estado) {
+        Venta venta = ventaRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Venta no encontrada"));
+
+        EstadoVenta estadoVenta = parseEstadoVenta(estado);
+        venta.setEstado(estadoVenta.toString());
+
+        Venta actualizada = ventaRepository.save(venta);
+        return toResponse(actualizada);
+    }
+
     // =========================================================
     // 🔧 Métodos auxiliares
     // =========================================================
@@ -205,6 +219,17 @@ public class VentaService {
                 .orElseGet(() -> vapeRepository.findById(productoId)
                         .<Producto>map(v -> v)
                         .orElseThrow(() -> new ResourceNotFoundException("Producto no encontrado con id: " + productoId)));
+    }
+
+    private EstadoVenta parseEstadoVenta(String estado) {
+        if (!StringUtils.hasText(estado)) {
+            throw new VesperException("El estado de la venta es obligatorio");
+        }
+        try {
+            return EstadoVenta.valueOf(estado.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new VesperException("Estado de venta inválido");
+        }
     }
 
     private VentaResponse toResponse(Venta venta) {

--- a/Frontend/admin.html
+++ b/Frontend/admin.html
@@ -74,6 +74,15 @@
     </div>
   </header>
 
+  <div class="admin-cta-bar" aria-label="Acceso rápido al panel de administrador">
+    <div class="container">
+      <a class="btn btn--primary admin-cta-button" href="admin.html">
+        <span class="material-symbols-outlined" aria-hidden="true">admin_panel_settings</span>
+        Panel de Administrador
+      </a>
+    </div>
+  </div>
+
   <nav class="site-header__bottom" aria-label="Categorías principales">
     <div class="container">
       <ul class="main-nav">
@@ -362,6 +371,30 @@
                     </tr>
                   </thead>
                   <tbody id="promotionsTableBody"></tbody>
+                </table>
+              </div>
+            </div>
+          </article>
+
+          <article class="accordion-item">
+            <button class="accordion-header" type="button" aria-expanded="false">
+              <span class="accordion-title">Administrar ventas</span>
+              <span class="material-symbols-outlined accordion-icon" aria-hidden="true">expand_more</span>
+            </button>
+            <div class="accordion-content" hidden>
+              <div class="table-wrapper">
+                <table class="admin-table admin-table--sales" aria-label="Listado de ventas">
+                  <thead>
+                    <tr>
+                      <th scope="col">ID</th>
+                      <th scope="col">Fecha</th>
+                      <th scope="col">Productos comprados</th>
+                      <th scope="col">Total</th>
+                      <th scope="col">Estado</th>
+                      <th scope="col">Datos del cliente</th>
+                    </tr>
+                  </thead>
+                  <tbody id="salesTableBody"></tbody>
                 </table>
               </div>
             </div>

--- a/Frontend/css/admin.css
+++ b/Frontend/css/admin.css
@@ -26,6 +26,31 @@
   font-size: 1rem;
 }
 
+.admin-cta-bar {
+  background: #ffffff;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.admin-cta-bar .container {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0 18px;
+}
+
+.admin-cta-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 22px;
+  border-radius: 999px;
+  box-shadow: 0 18px 32px -26px rgba(15, 23, 42, 0.45);
+  text-transform: none;
+}
+
+.admin-cta-button .material-symbols-outlined {
+  font-size: 1.2rem;
+}
+
 .accordion {
   display: grid;
   gap: 16px;
@@ -291,6 +316,10 @@
   background: #ffffff;
 }
 
+.admin-table--sales {
+  min-width: 980px;
+}
+
 .admin-table th,
 .admin-table td {
   padding: 16px 18px;
@@ -376,6 +405,50 @@
   color: #004aad;
 }
 
+.sales-products,
+.sales-customer {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #475569;
+  font-size: 0.92rem;
+}
+
+.sales-customer strong {
+  color: #0b1f44;
+}
+
+.order-status-select {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  background: rgba(148, 163, 184, 0.18);
+  color: #334155;
+}
+
+.order-status-select.is-pending {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.order-status-select.is-shipped {
+  background: rgba(245, 158, 11, 0.18);
+  color: #b45309;
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+.order-status-select.is-received {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
 .dynamic-flavors {
   display: grid;
   gap: 14px;
@@ -452,6 +525,15 @@
 @media (max-width: 768px) {
   .accordion-header {
     padding: 18px 20px;
+  }
+
+  .admin-cta-bar .container {
+    padding: 8px 0 16px;
+  }
+
+  .admin-cta-button {
+    width: 100%;
+    justify-content: center;
   }
 
   .admin-modal {

--- a/Frontend/javaScript/admin.js
+++ b/Frontend/javaScript/admin.js
@@ -3,9 +3,14 @@ const currencyFormatter = new Intl.NumberFormat('es-AR', {
   currency: 'ARS',
   maximumFractionDigits: 0
 });
+const dateFormatter = new Intl.DateTimeFormat('es-AR', {
+  dateStyle: 'medium',
+  timeStyle: 'short'
+});
 
 let products = [];
 const promotions = [];
+let sales = [];
 let apiClient = null;
 
 const dom = {
@@ -24,7 +29,8 @@ const dom = {
   featuredTableBody: document.getElementById('featuredProductsBody'),
   featuredSelect: document.getElementById('featuredProductSelect'),
   addFeaturedButton: document.getElementById('addFeaturedButton'),
-  featuredCounter: document.getElementById('featuredCounter')
+  featuredCounter: document.getElementById('featuredCounter'),
+  salesTableBody: document.getElementById('salesTableBody')
 };
 
 let addProductHelpers;
@@ -71,11 +77,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     await ensureApiClient();
     await loadProductsFromApi();
     await loadFeaturedProducts();
+    await loadSalesFromApi();
   } catch (error) {
     console.error('Error inicializando la API del administrador:', error);
     showToast('No se pudieron cargar los productos del catálogo.');
     renderProductsTable();
     renderFeaturedProducts('No se pudo obtener la lista de destacados.');
+    renderSalesTable('No se pudo obtener el listado de ventas.');
   }
 
   renderPromotionsTable();
@@ -88,6 +96,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     const destacadoId = Number.parseInt(target.dataset.featuredId, 10);
     if (!Number.isFinite(destacadoId)) return;
     removeFeaturedProduct(destacadoId);
+  });
+
+  dom.salesTableBody?.addEventListener('change', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLSelectElement)) return;
+    if (!target.classList.contains('order-status-select')) return;
+    handleSaleStatusChange(target);
   });
 
 
@@ -128,23 +143,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else if (Date.now() - start > timeoutMs) {
           clearInterval(interval);
           resolve(null);
-        }
-      }, 100);
-    });
-  }
-
-  async function ensureApiClient() {
-    if (window.apiClient) return window.apiClient;
-
-    return new Promise((resolve, reject) => {
-      const start = Date.now();
-      const interval = setInterval(() => {
-        if (window.apiClient) {
-          clearInterval(interval);
-          resolve(window.apiClient);
-        } else if (Date.now() - start > 10000) {
-          clearInterval(interval);
-          reject(new Error('API Client initialized timeout'));
         }
       }, 100);
     });
@@ -304,6 +302,228 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 });
+
+async function ensureApiClient() {
+  if (window.apiClient) return window.apiClient;
+
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      if (window.apiClient) {
+        clearInterval(interval);
+        resolve(window.apiClient);
+      } else if (Date.now() - start > 10000) {
+        clearInterval(interval);
+        reject(new Error('API Client initialized timeout'));
+      }
+    }, 100);
+  });
+}
+
+async function loadSalesFromApi() {
+  if (!dom.salesTableBody) return;
+  try {
+    const client = await ensureApiClient();
+    if (!client) throw new Error('Cliente de API no disponible.');
+    const data = await client.request('/admin/ventas', { authenticated: true });
+    sales = Array.isArray(data) ? data : [];
+    renderSalesTable();
+  } catch (error) {
+    console.error('Error al obtener ventas:', error);
+    sales = [];
+    renderSalesTable('No se pudieron cargar las ventas.');
+  }
+}
+
+function renderSalesTable(message) {
+  if (!dom.salesTableBody) return;
+  dom.salesTableBody.innerHTML = '';
+
+  if (message) {
+    dom.salesTableBody.append(createEmptySalesRow(message));
+    return;
+  }
+
+  if (!sales.length) {
+    dom.salesTableBody.append(createEmptySalesRow('Todavía no hay ventas registradas.'));
+    return;
+  }
+
+  sales.forEach((venta) => {
+    const row = document.createElement('tr');
+
+    const idCell = document.createElement('td');
+    idCell.textContent = venta.id ?? '-';
+
+    const dateCell = document.createElement('td');
+    dateCell.textContent = formatSaleDate(venta.fecha);
+
+    const productsCell = document.createElement('td');
+    productsCell.append(createProductsList(venta.detalles));
+
+    const totalCell = document.createElement('td');
+    totalCell.textContent = typeof venta.total === 'number'
+      ? currencyFormatter.format(venta.total)
+      : '-';
+
+    const statusCell = document.createElement('td');
+    const statusSelect = createStatusSelect(venta);
+    statusCell.append(statusSelect);
+
+    const customerCell = document.createElement('td');
+    customerCell.append(createCustomerList(venta));
+
+    row.append(idCell, dateCell, productsCell, totalCell, statusCell, customerCell);
+    dom.salesTableBody.append(row);
+  });
+}
+
+function createEmptySalesRow(message) {
+  const row = document.createElement('tr');
+  const cell = document.createElement('td');
+  cell.colSpan = 6;
+  cell.innerHTML = `
+    <div class="empty-state">
+      <span class="material-symbols-outlined" aria-hidden="true">receipt_long</span>
+      <p>${message}</p>
+    </div>
+  `;
+  row.append(cell);
+  return row;
+}
+
+function formatSaleDate(rawDate) {
+  if (!rawDate) return '-';
+  const parsed = new Date(rawDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return String(rawDate);
+  }
+  return dateFormatter.format(parsed);
+}
+
+function createProductsList(detalles) {
+  const list = document.createElement('ul');
+  list.className = 'sales-products';
+  if (!Array.isArray(detalles) || detalles.length === 0) {
+    const item = document.createElement('li');
+    item.textContent = 'Sin detalle de productos.';
+    list.append(item);
+    return list;
+  }
+
+  detalles.forEach((detalle) => {
+    const item = document.createElement('li');
+    const quantity = detalle.cantidad ? `x${detalle.cantidad}` : '';
+    const subtotal = typeof detalle.subtotal === 'number'
+      ? ` · ${currencyFormatter.format(detalle.subtotal)}`
+      : '';
+    item.textContent = `${detalle.nombreProducto ?? 'Producto'} ${quantity}${subtotal}`.trim();
+    list.append(item);
+  });
+  return list;
+}
+
+function createCustomerList(venta) {
+  const list = document.createElement('ul');
+  list.className = 'sales-customer';
+
+  const customerName = [venta.nombreCliente, venta.apellidoCliente]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+  const email = venta.usuarioEmail || venta.emailCliente || venta.email || '-';
+  const address = venta.direccionCliente || venta.direccion || venta.address || '-';
+  const phone = venta.telefonoCliente || venta.telefono || venta.phone || '-';
+
+  list.append(
+    createCustomerItem('Nombre', customerName || 'No informado'),
+    createCustomerItem('Correo', email),
+    createCustomerItem('Dirección', address),
+    createCustomerItem('Teléfono', phone)
+  );
+
+  return list;
+}
+
+function createCustomerItem(label, value) {
+  const item = document.createElement('li');
+  const strong = document.createElement('strong');
+  strong.textContent = `${label}: `;
+  const span = document.createElement('span');
+  span.textContent = value;
+  item.append(strong, span);
+  return item;
+}
+
+function createStatusSelect(venta) {
+  const select = document.createElement('select');
+  select.className = 'order-status-select';
+  const normalizedStatus = normalizeSaleStatus(venta.estado);
+  select.dataset.saleId = venta.id ?? '';
+  select.dataset.currentStatus = normalizedStatus;
+
+  [
+    { value: 'PENDIENTE', label: 'Pendiente' },
+    { value: 'ENVIADO', label: 'Enviado' },
+    { value: 'RECIBIDO', label: 'Recibido' }
+  ].forEach((optionData) => {
+    const option = document.createElement('option');
+    option.value = optionData.value;
+    option.textContent = optionData.label;
+    select.append(option);
+  });
+
+  select.value = normalizedStatus;
+  applyStatusSelectStyle(select, normalizedStatus);
+  return select;
+}
+
+function normalizeSaleStatus(rawStatus) {
+  const status = String(rawStatus || '').toUpperCase();
+  if (status === 'ENVIADO') return 'ENVIADO';
+  if (status === 'RECIBIDO' || status === 'COMPLETADA') return 'RECIBIDO';
+  return 'PENDIENTE';
+}
+
+function applyStatusSelectStyle(select, status) {
+  select.classList.remove('is-pending', 'is-shipped', 'is-received');
+  if (status === 'ENVIADO') {
+    select.classList.add('is-shipped');
+  } else if (status === 'RECIBIDO') {
+    select.classList.add('is-received');
+  } else {
+    select.classList.add('is-pending');
+  }
+}
+
+async function handleSaleStatusChange(select) {
+  const saleId = Number.parseInt(select.dataset.saleId, 10);
+  if (!Number.isFinite(saleId)) return;
+  const previousStatus = select.dataset.currentStatus || 'PENDIENTE';
+  const newStatus = select.value;
+  applyStatusSelectStyle(select, newStatus);
+
+  try {
+    const client = await ensureApiClient();
+    if (!client) throw new Error('Cliente de API no disponible.');
+    await client.request(`/admin/ventas/${saleId}/estado`, {
+      method: 'PUT',
+      body: { estado: newStatus },
+      authenticated: true
+    });
+    select.dataset.currentStatus = newStatus;
+    const sale = sales.find((item) => Number(item.id) === saleId);
+    if (sale) {
+      sale.estado = newStatus;
+    }
+    showToast('Estado de la venta actualizado.');
+  } catch (error) {
+    console.error('Error al actualizar el estado de la venta:', error);
+    showToast('No se pudo actualizar el estado de la venta.');
+    select.value = previousStatus;
+    applyStatusSelectStyle(select, previousStatus);
+  }
+}
 
 
 function setupAccordions() {


### PR DESCRIPTION
### Motivation
- Proveer una vista en el panel de administración para listar y gestionar ventas almacenadas en el backend.  
- Permitir al administrador actualizar el estado de cada venta (Pendiente / Enviado / Recibido) desde la UI.  
- Integrar la funcionalidad manteniendo el estilo visual y comportamiento responsive del panel existente.  
- Añadir soporte backend para recibir y validar cambios de estado desde la interfaz administrativa.  

### Description
- Frontend: se añadió botón `Panel de Administrador` bajo la barra de búsqueda y una nueva sección acordeón `Administrar ventas` con tabla (`#salesTableBody`) y select de estado; se implementaron funciones JS para `loadSalesFromApi`, renderizado (`renderSalesTable`) y envío de cambios (`handleSaleStatusChange`).  
- Frontend: reutiliza estilos existentes y se añadieron reglas en `Frontend/css/admin.css` para la barra CTA, tabla de ventas y clases de estado (`.order-status-select`, `.is-pending`, `.is-shipped`, `.is-received`) adaptadas a móviles.  
- Backend: se amplió el enum de estados en `Venta` para incluir `ENVIADO` y `RECIBIDO`, se agregó DTO `VentaEstadoRequest` y un nuevo endpoint admin `PUT /api/admin/ventas/{id}/estado` en `VentaController`.  
- Backend: `VentaService` incorpora `actualizarEstado` y validación de estados (`parseEstadoVenta`) con errores controlados para entradas inválidas.  

### Testing
- Ejecuté la suite de pruebas automática del backend con `./gradlew test` y finalizó correctamente (`BUILD SUCCESSFUL`).  
- La UI fue probada localmente en el DOM (simulación de guardias Auth0 removidos para mostrar la interfaz) y el listado/selector renderizan correctamente en navegadores; las interacciones de cambio de estado llaman al endpoint admin.  
- Se manejan errores de API en UI mostrando `showToast` cuando la actualización falla.  
- (Nota) La captura de pantalla automática falló al intentar leer el archivo local con Playwright; esto no afecta las pruebas unitarias ejecutadas en backend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b4119234832ea0194baab7fb1cb0)